### PR TITLE
Config overrides, logging improvements

### DIFF
--- a/compose-example.yaml
+++ b/compose-example.yaml
@@ -1,18 +1,17 @@
-services:
-  # Common benchmark service template
-  bench_base: &bench_base
-    build:
-      context: ./redbench
-      dockerfile: Dockerfile
-    volumes:
-      - ./redbench/config.yaml:/config.yaml
-    restart: no
-    depends_on:
-      - prometheus
-      - redis8
-      - redis7
-      - valkey
+x-bench_base: &bench_base
+  build:
+    context: ./redbench
+    dockerfile: Dockerfile
+  volumes:
+    - ./redbench/config.yaml:/config.yaml
+  restart: no
+  depends_on:
+    - prometheus
+    - redis8
+    - redis7
+    - valkey
 
+services:
   bench_redis8:
     <<: *bench_base
     ports:

--- a/redbench/go.mod
+++ b/redbench/go.mod
@@ -5,7 +5,6 @@ go 1.23.5
 toolchain go1.24.2
 
 require (
-	github.com/davecgh/go-spew v1.1.1
 	github.com/prometheus/client_golang v1.22.0
 	github.com/redis/go-redis/v9 v9.7.3
 	gopkg.in/yaml.v2 v2.4.0

--- a/redbench/main.go
+++ b/redbench/main.go
@@ -37,6 +37,8 @@ func main() {
 	cfg := new(Config)
 	cfg.loadConfig("config.yaml")
 
+	slog.Info("Loaded configuration", "event", "config_loaded", "data", cfg)
+
 	reg := prometheus.NewRegistry()
 	m := NewMetrics(reg, host+":"+port)
 	StartPrometheusServer(cfg, reg)
@@ -56,7 +58,7 @@ func runTest(cfg Config, m *metrics) {
 		Protocol:        2,
 		DisableIdentity: true,
 	}
-	slog.Info("Redis Options", "options", fmt.Sprintf("%+v", opts))
+	slog.Info("Redis options", "event", "redis_options", "data", opts)
 	rdb := redis.NewClient(opts)
 
 	// Periodically update Redis pool stats metrics

--- a/redbench/main.go
+++ b/redbench/main.go
@@ -46,6 +46,13 @@ func main() {
 	runTest(*cfg, m)
 }
 
+// RedisOptsLog is a serializable subset of redis.Options for logging
+type RedisOptsLog struct {
+	Addr     string `json:"addr"`
+	DB       int    `json:"db"`
+	Protocol int    `json:"protocol"`
+}
+
 func runTest(cfg Config, m *metrics) {
 
 	var ctx = context.Background()
@@ -58,7 +65,11 @@ func runTest(cfg Config, m *metrics) {
 		Protocol:        2,
 		DisableIdentity: true,
 	}
-	slog.Info("Redis options", "event", "redis_options", "data", opts)
+	slog.Info("Redis options", "event", "redis_options", "data", RedisOptsLog{
+		Addr:     opts.Addr,
+		DB:       opts.DB,
+		Protocol: opts.Protocol,
+	})
 	rdb := redis.NewClient(opts)
 
 	// Periodically update Redis pool stats metrics

--- a/redbench/redisdata.go
+++ b/redbench/redisdata.go
@@ -12,12 +12,7 @@ import (
 
 // randomString generates a random alphanumeric string of the given length.
 func randomString(length int) string {
-	fmt.Printf("randomString called with length=%d\n", length)
-	if length <= 0 {
-		panic("randomString: length must be > 0, got " + fmt.Sprint(length))
-	}
 	const letters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
-	fmt.Printf("letters=%q, len(letters)=%d\n", letters, len(letters))
 	result := make([]byte, length)
 	for i := range result {
 		result[i] = letters[rand.Intn(len(letters))]

--- a/redbench/redisdata.go
+++ b/redbench/redisdata.go
@@ -10,8 +10,6 @@ import (
 	"github.com/redis/go-redis/v9"
 )
 
-var seededRand *rand.Rand = rand.New(rand.NewSource(time.Now().UnixNano()))
-
 // randomString generates a random alphanumeric string of the given length.
 func randomString(length int) string {
 	fmt.Printf("randomString called with length=%d\n", length)
@@ -22,7 +20,7 @@ func randomString(length int) string {
 	fmt.Printf("letters=%q, len(letters)=%d\n", letters, len(letters))
 	result := make([]byte, length)
 	for i := range result {
-		result[i] = letters[seededRand.Intn(len(letters))]
+		result[i] = letters[rand.Intn(len(letters))]
 	}
 	return string(result)
 }

--- a/redbench/redisdata.go
+++ b/redbench/redisdata.go
@@ -19,6 +19,7 @@ func randomString(length int) string {
 		panic("randomString: length must be > 0, got " + fmt.Sprint(length))
 	}
 	const letters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+	fmt.Printf("letters=%q, len(letters)=%d\n", letters, len(letters))
 	result := make([]byte, length)
 	for i := range result {
 		result[i] = letters[seededRand.Intn(len(letters))]

--- a/redbench/redisdata.go
+++ b/redbench/redisdata.go
@@ -14,6 +14,7 @@ var seededRand *rand.Rand = rand.New(rand.NewSource(time.Now().UnixNano()))
 
 // randomString generates a random alphanumeric string of the given length.
 func randomString(length int) string {
+	fmt.Printf("randomString called with length=%d\n", length)
 	if length <= 0 {
 		panic("randomString: length must be > 0, got " + fmt.Sprint(length))
 	}

--- a/redbench/redisdata.go
+++ b/redbench/redisdata.go
@@ -14,6 +14,9 @@ var seededRand *rand.Rand = rand.New(rand.NewSource(time.Now().UnixNano()))
 
 // randomString generates a random alphanumeric string of the given length.
 func randomString(length int) string {
+	if length <= 0 {
+		panic("randomString: length must be > 0, got " + fmt.Sprint(length))
+	}
 	const letters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
 	result := make([]byte, length)
 	for i := range result {


### PR DESCRIPTION
This pull request introduces several updates to the `redbench` project, focusing on configuration handling, logging improvements, and code cleanup. Key changes include adding environment variable overrides for configuration fields, migrating to structured logging with `slog`, and removing unnecessary dependencies. Below is a categorized summary of the most important changes:

### Configuration Enhancements
* Added logic in `redbench/config.go` to override configuration fields using environment variables. This uses reflection to dynamically map environment variables to struct fields.
* Introduced a helper function `toEnvName` to convert CamelCase field names to uppercase snake case for environment variable compatibility.

### Logging Improvements
* Replaced `log` with `slog` for structured logging, including JSON output setup in `redbench/main.go`. This improves log readability and consistency [[1]](diffhunk://#diff-ef66cd4967eec668e5fc1f01db1bc9e4309e6c96a4c8479e185dcf76f3611162L6-L12) [[2]](diffhunk://#diff-ef66cd4967eec668e5fc1f01db1bc9e4309e6c96a4c8479e185dcf76f3611162R21-R28).
* Added structured logs for configuration loading, Redis options, and error handling in `redbench/main.go` [[1]](diffhunk://#diff-ef66cd4967eec668e5fc1f01db1bc9e4309e6c96a4c8479e185dcf76f3611162R40-R55) [[2]](diffhunk://#diff-ef66cd4967eec668e5fc1f01db1bc9e4309e6c96a4c8479e185dcf76f3611162L55-R72) [[3]](diffhunk://#diff-ef66cd4967eec668e5fc1f01db1bc9e4309e6c96a4c8479e185dcf76f3611162L84-R99) [[4]](diffhunk://#diff-ef66cd4967eec668e5fc1f01db1bc9e4309e6c96a4c8479e185dcf76f3611162L93-R108).

### Dependency Updates and Cleanup
* Removed the unused `github.com/davecgh/go-spew` dependency from `redbench/go.mod`.
* Eliminated the custom `seededRand` in `redbench/redisdata.go` in favor of the default `rand` package for simplicity.

### Docker Compose Adjustments
* Updated the `compose-example.yaml` file to fix an issue with the `bench_base` service anchor by prefixing it with `x-`.
* Reorganized the `services` section in `compose-example.yaml` to include a new `bench_redis8` service.