### PR TITLE
unify ports for api/metrics

### DIFF
--- a/compose-example.yaml
+++ b/compose-example.yaml
@@ -15,21 +15,21 @@ services:
   bench_redis8:
     <<: *bench_base
     ports:
-      - "8081:8081"
+      - "8081:8080"
     environment:
       - REDIS_URL=redis://redis8:6379
 
   bench_redis7:
     <<: *bench_base
     ports:
-      - "8083:8081"
+      - "8083:8080"
     environment:
       - REDIS_URL=redis://redis7:6379
 
   bench_valkey:
     <<: *bench_base
     ports:
-      - "8082:8081"
+      - "8082:8080"
     environment:
       - REDIS_URL=redis://valkey:6379
 

--- a/prometheus/prometheus.yml
+++ b/prometheus/prometheus.yml
@@ -11,9 +11,9 @@ scrape_configs:
   scheme: http
   static_configs:
   - targets:
-    - bench_redis8:8081
-    - bench_redis7:8081
-    - bench_valkey:8081
+    - bench_redis8:8080
+    - bench_redis7:8080
+    - bench_valkey:8080
 
 - job_name: redis_exporters
   honor_timestamps: true

--- a/redbench/README.md
+++ b/redbench/README.md
@@ -183,7 +183,7 @@ curl -X POST http://localhost:8080/start \
 {
   "status": "running",
   "configuration": {
-    "MetricsPort": 8081,
+    "MetricsPort": 8080,
     "Debug": false,
     "Redis": { ... },
     "Test": { ... }
@@ -219,11 +219,11 @@ Redis connection requires either URL or ClusterURL to be specified
 
 ### Prometheus Metrics
 
-Metrics are available at `http://localhost:8081/metrics`:
+Metrics are available at `http://localhost:8080/metrics` (unified port for both CLI and service modes):
 
 ```bash
 # View all redbench metrics
-curl http://localhost:8081/metrics | grep redbench
+curl http://localhost:8080/metrics | grep redbench
 ```
 
 Key metrics:
@@ -314,9 +314,9 @@ GitHub Actions automatically runs:
    - Check server name matches certificate
    - Use `insecureSkipVerify: true` only for testing
 
-3. **Service mode port conflicts**
-   - Change API port: `API_PORT=9090 ./redbench -service`
-   - Change metrics port in `config.yaml`
+3. **Port conflicts**
+   - Change API/metrics port: `API_PORT=9090 ./redbench -service`
+   - Both API and metrics now use the same unified port (8080 by default)
 
 ### Debug Mode
 

--- a/redbench/cmd/redbench/main.go
+++ b/redbench/cmd/redbench/main.go
@@ -61,13 +61,15 @@ func main() {
 
 	// Initialize metrics registry (shared by both modes)
 	reg := prometheus.NewRegistry()
-	metrics.StartPrometheusServer(cfg.MetricsPort, reg)
 
 	if *serviceMode {
-		// Run in service mode
+		// Run in service mode (metrics served on same port as API)
 		runServiceMode(cfg, redisConn, reg)
 	} else {
-		// Run in traditional CLI mode - initialize Redis client and metrics for single run
+		// Run in traditional CLI mode - start metrics server on port 8080
+		metrics.StartPrometheusServer(8080, reg)
+
+		// Initialize Redis client and metrics for single run
 		redisClient, err := redis.NewRedisClient(redisConn)
 		if err != nil {
 			slog.Error("Failed to initialize Redis client", "error", err)

--- a/redbench/config.yaml
+++ b/redbench/config.yaml
@@ -1,5 +1,5 @@
 ---
-metricsPort: 8081
+metricsPort: 8080
 debug: false
 redis:
   expirationS: 20

--- a/redbench/internal/config/config_test.go
+++ b/redbench/internal/config/config_test.go
@@ -15,7 +15,7 @@ func TestLoadConfig(t *testing.T) {
 	defer os.Remove(tmpFile.Name())
 
 	configContent := `
-metricsPort: 8081
+metricsPort: 8080
 debug: true
 redis:
   expirationS: 30
@@ -37,7 +37,7 @@ test:
 	require.NoError(t, err)
 
 	// Verify config values
-	assert.Equal(t, 8081, cfg.MetricsPort)
+	assert.Equal(t, 8080, cfg.MetricsPort)
 	assert.True(t, cfg.Debug)
 	assert.Equal(t, int32(30), cfg.Redis.Expiration)
 	assert.Equal(t, 100, cfg.Redis.OperationTimeoutMs)
@@ -56,7 +56,7 @@ func TestLoadConfigWithEnvOverrides(t *testing.T) {
 	defer os.Remove(tmpFile.Name())
 
 	configContent := `
-metricsPort: 8081
+metricsPort: 8080
 debug: true
 redis:
   expirationS: 30

--- a/redbench/internal/service/config_test.go
+++ b/redbench/internal/service/config_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestMergeConfiguration_EmptyBody(t *testing.T) {
 	baseConfig := &config.Config{
-		MetricsPort: 8081,
+		MetricsPort: 8080,
 		Test: config.Test{
 			MinClients:      1,
 			MaxClients:      100,
@@ -36,7 +36,7 @@ func TestMergeConfiguration_EmptyBody(t *testing.T) {
 
 func TestMergeConfiguration_WithOverrides(t *testing.T) {
 	baseConfig := &config.Config{
-		MetricsPort: 8081,
+		MetricsPort: 8080,
 		Test: config.Test{
 			MinClients:      1,
 			MaxClients:      100,
@@ -131,7 +131,7 @@ func TestMergeConfiguration_WithRedisOverrides(t *testing.T) {
 
 func TestMergeConfiguration_PartialOverrides(t *testing.T) {
 	baseConfig := &config.Config{
-		MetricsPort: 8081,
+		MetricsPort: 8080,
 		Test: config.Test{
 			MinClients:      1,
 			MaxClients:      100,
@@ -181,7 +181,7 @@ func TestMergeConfiguration_InvalidJSON(t *testing.T) {
 
 func TestMergeConfiguration_NoTestOverrides(t *testing.T) {
 	baseConfig := &config.Config{
-		MetricsPort: 8081,
+		MetricsPort: 8080,
 		Test: config.Test{
 			MinClients: 1,
 			MaxClients: 100,

--- a/redbench/internal/service/server.go
+++ b/redbench/internal/service/server.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 
 	"github.com/simonasr/benchmarketing/redbench/internal/config"
 )
@@ -27,6 +28,10 @@ func NewServer(port int, baseConfig *config.Config, redisConn *config.RedisConne
 	mux.HandleFunc("/status", service.StatusHandler)
 	mux.HandleFunc("/start", service.StartHandler)
 	mux.HandleFunc("/stop", service.StopHandler)
+
+	// Add metrics endpoint to the same server
+	promHandler := promhttp.HandlerFor(metricsRegistry, promhttp.HandlerOpts{})
+	mux.Handle("/metrics", promHandler)
 
 	httpServer := &http.Server{
 		Addr:         fmt.Sprintf(":%d", port),

--- a/redbench/internal/service/state_test.go
+++ b/redbench/internal/service/state_test.go
@@ -35,7 +35,7 @@ func TestGlobalState_InitialState(t *testing.T) {
 func TestGlobalState_StartBenchmark(t *testing.T) {
 	gs := NewGlobalState()
 	cfg := &config.Config{
-		MetricsPort: 8081,
+		MetricsPort: 8080,
 		Test: config.Test{
 			MinClients: 1,
 			MaxClients: 10,

--- a/redbench/test/integration/integration_test.go
+++ b/redbench/test/integration/integration_test.go
@@ -74,7 +74,7 @@ func TestIntegrationWithRedis(t *testing.T) {
 func TestIntegrationWithConfig(t *testing.T) {
 	// Create a test config
 	cfg := &config.Config{
-		MetricsPort: 8081,
+		MetricsPort: 8080,
 		Debug:       true,
 		Redis: config.RedisConfig{
 			Expiration:         30,


### PR DESCRIPTION
This PR unifies the ports used by the API and metrics endpoints, consolidating them to use a single port (8080) instead of separate ports for the API (8080) and metrics (8081).

- Updated all configuration files and tests to use port 8080 for metrics instead of 8081
- Modified the server to serve metrics on the same port as the API endpoints
- Updated documentation and Docker Compose configurations to reflect the unified port approach