### PR TITLE
redibench: fix metrics

### DIFF
--- a/redbench/internal/metrics/metrics.go
+++ b/redbench/internal/metrics/metrics.go
@@ -28,10 +28,10 @@ type Metrics struct {
 }
 
 // registerGauge registers a Gauge or reuses the existing collector if already registered.
-// Always returns a non-nil Gauge, falling back to the provided one on errors.
+// Always returns a non-nil Gauge, panicking on a nil input.
 func registerGauge(reg prometheus.Registerer, gauge prometheus.Gauge) prometheus.Gauge {
 	if gauge == nil {
-		return prometheus.NewGauge(prometheus.GaugeOpts{Name: "noop_gauge"})
+		panic("registerGauge: nil gauge provided")
 	}
 	if err := reg.Register(gauge); err != nil {
 		var are prometheus.AlreadyRegisteredError
@@ -52,10 +52,10 @@ func registerGauge(reg prometheus.Registerer, gauge prometheus.Gauge) prometheus
 }
 
 // registerHistogram registers a HistogramVec or reuses the existing one.
-// Always returns a non-nil HistogramVec, falling back to the provided one on errors.
+// Always returns a non-nil HistogramVec, panicking on a nil input.
 func registerHistogram(reg prometheus.Registerer, hv *prometheus.HistogramVec) *prometheus.HistogramVec {
 	if hv == nil {
-		return prometheus.NewHistogramVec(prometheus.HistogramOpts{Name: "noop_histogram"}, []string{"noop"})
+		panic("registerHistogram: nil HistogramVec provided")
 	}
 	if err := reg.Register(hv); err != nil {
 		var are prometheus.AlreadyRegisteredError
@@ -76,10 +76,10 @@ func registerHistogram(reg prometheus.Registerer, hv *prometheus.HistogramVec) *
 }
 
 // registerCounter registers a CounterVec or reuses the existing one.
-// Always returns a non-nil CounterVec, falling back to the provided one on errors.
+// Always returns a non-nil CounterVec, panicking on a nil input.
 func registerCounter(reg prometheus.Registerer, cv *prometheus.CounterVec) *prometheus.CounterVec {
 	if cv == nil {
-		return prometheus.NewCounterVec(prometheus.CounterOpts{Name: "noop_counter"}, []string{"noop"})
+		panic("registerCounter: nil CounterVec provided")
 	}
 	if err := reg.Register(cv); err != nil {
 		var are prometheus.AlreadyRegisteredError

--- a/redbench/internal/metrics/metrics.go
+++ b/redbench/internal/metrics/metrics.go
@@ -87,21 +87,28 @@ func New(reg prometheus.Registerer, target string) *Metrics {
 	}
 
 	// Register metrics, handling duplicates gracefully
-	collectors := []prometheus.Collector{
-		m.duration, m.stage, m.requestFailed,
-		m.redisPoolTotalConns, m.redisPoolIdleConns, m.redisPoolStaleConns,
-		m.redisPoolHits, m.redisPoolMisses, m.redisPoolTimeouts,
-	}
-
-	for _, collector := range collectors {
-		if err := reg.Register(collector); err != nil {
-			// Check if it's already registered - this is expected for subsequent benchmarks
-			if _, ok := err.(prometheus.AlreadyRegisteredError); !ok {
+	assignOrReuse := func(c prometheus.Collector, assign func(prometheus.Collector)) {
+		if err := reg.Register(c); err != nil {
+			if are, ok := err.(prometheus.AlreadyRegisteredError); ok {
+				assign(are.ExistingCollector)
+			} else {
 				slog.Error("Failed to register metric", "error", err)
-				// Continue with other metrics even if one fails
 			}
+		} else {
+			assign(c)
 		}
 	}
+
+	assignOrReuse(m.stage, func(ec prometheus.Collector) { m.stage = ec.(prometheus.Gauge) })
+	assignOrReuse(m.duration, func(ec prometheus.Collector) { m.duration = ec.(*prometheus.HistogramVec) })
+	assignOrReuse(m.requestFailed, func(ec prometheus.Collector) { m.requestFailed = ec.(*prometheus.CounterVec) })
+
+	assignOrReuse(m.redisPoolTotalConns, func(ec prometheus.Collector) { m.redisPoolTotalConns = ec.(prometheus.Gauge) })
+	assignOrReuse(m.redisPoolIdleConns, func(ec prometheus.Collector) { m.redisPoolIdleConns = ec.(prometheus.Gauge) })
+	assignOrReuse(m.redisPoolStaleConns, func(ec prometheus.Collector) { m.redisPoolStaleConns = ec.(prometheus.Gauge) })
+	assignOrReuse(m.redisPoolHits, func(ec prometheus.Collector) { m.redisPoolHits = ec.(prometheus.Gauge) })
+	assignOrReuse(m.redisPoolMisses, func(ec prometheus.Collector) { m.redisPoolMisses = ec.(prometheus.Gauge) })
+	assignOrReuse(m.redisPoolTimeouts, func(ec prometheus.Collector) { m.redisPoolTimeouts = ec.(prometheus.Gauge) })
 
 	return m
 }

--- a/redbench/internal/metrics/metrics.go
+++ b/redbench/internal/metrics/metrics.go
@@ -27,6 +27,67 @@ type Metrics struct {
 	target string
 }
 
+// registerGauge registers a Gauge or reuses the existing collector if already registered.
+// Returns the registered (or reused) Gauge, or nil on failure.
+func registerGauge(reg prometheus.Registerer, gauge prometheus.Gauge) prometheus.Gauge {
+	if gauge == nil {
+		return nil
+	}
+	if err := reg.Register(gauge); err != nil {
+		var are prometheus.AlreadyRegisteredError
+		if errors.As(err, &are) {
+			if g, ok := are.ExistingCollector.(prometheus.Gauge); ok {
+				return g
+			}
+			slog.Error("Existing collector is not a prometheus.Gauge")
+			return nil
+		}
+		slog.Error("Failed to register metric", "error", err)
+		return nil
+	}
+	return gauge
+}
+
+// registerHistogram registers a HistogramVec or reuses the existing one. Returns nil on failure.
+func registerHistogram(reg prometheus.Registerer, hv *prometheus.HistogramVec) *prometheus.HistogramVec {
+	if hv == nil {
+		return nil
+	}
+	if err := reg.Register(hv); err != nil {
+		var are prometheus.AlreadyRegisteredError
+		if errors.As(err, &are) {
+			if existing, ok := are.ExistingCollector.(*prometheus.HistogramVec); ok {
+				return existing
+			}
+			slog.Error("Existing collector is not a *prometheus.HistogramVec")
+			return nil
+		}
+		slog.Error("Failed to register metric", "error", err)
+		return nil
+	}
+	return hv
+}
+
+// registerCounter registers a CounterVec or reuses the existing one. Returns nil on failure.
+func registerCounter(reg prometheus.Registerer, cv *prometheus.CounterVec) *prometheus.CounterVec {
+	if cv == nil {
+		return nil
+	}
+	if err := reg.Register(cv); err != nil {
+		var are prometheus.AlreadyRegisteredError
+		if errors.As(err, &are) {
+			if existing, ok := are.ExistingCollector.(*prometheus.CounterVec); ok {
+				return existing
+			}
+			slog.Error("Existing collector is not a *prometheus.CounterVec")
+			return nil
+		}
+		slog.Error("Failed to register metric", "error", err)
+		return nil
+	}
+	return cv
+}
+
 // New creates a new Metrics instance with the provided registry and target label.
 func New(reg prometheus.Registerer, target string) *Metrics {
 	m := &Metrics{
@@ -87,84 +148,17 @@ func New(reg prometheus.Registerer, target string) *Metrics {
 		}),
 	}
 
-	// Register metrics, handling duplicates gracefully (supporting wrapped errors)
-	assignOrReuse := func(c prometheus.Collector, assign func(prometheus.Collector)) {
-		if err := reg.Register(c); err != nil {
-			var are prometheus.AlreadyRegisteredError
-			if errors.As(err, &are) {
-				assign(are.ExistingCollector)
-			} else {
-				slog.Error("Failed to register metric", "error", err)
-			}
-		} else {
-			assign(c)
-		}
-	}
+	// Register or reuse collectors
+	m.stage = registerGauge(reg, m.stage)
+	m.duration = registerHistogram(reg, m.duration)
+	m.requestFailed = registerCounter(reg, m.requestFailed)
 
-	assignOrReuse(m.stage, func(ec prometheus.Collector) {
-		if g, ok := ec.(prometheus.Gauge); ok {
-			m.stage = g
-		} else {
-			slog.Error("Existing collector for stage is not a prometheus.Gauge")
-		}
-	})
-	assignOrReuse(m.duration, func(ec prometheus.Collector) {
-		if hv, ok := ec.(*prometheus.HistogramVec); ok {
-			m.duration = hv
-		} else {
-			slog.Error("Existing collector for duration is not a *prometheus.HistogramVec")
-		}
-	})
-	assignOrReuse(m.requestFailed, func(ec prometheus.Collector) {
-		if cv, ok := ec.(*prometheus.CounterVec); ok {
-			m.requestFailed = cv
-		} else {
-			slog.Error("Existing collector for requestFailed is not a *prometheus.CounterVec")
-		}
-	})
-
-	assignOrReuse(m.redisPoolTotalConns, func(ec prometheus.Collector) {
-		if g, ok := ec.(prometheus.Gauge); ok {
-			m.redisPoolTotalConns = g
-		} else {
-			slog.Error("Existing collector for redisPoolTotalConns is not a prometheus.Gauge")
-		}
-	})
-	assignOrReuse(m.redisPoolIdleConns, func(ec prometheus.Collector) {
-		if g, ok := ec.(prometheus.Gauge); ok {
-			m.redisPoolIdleConns = g
-		} else {
-			slog.Error("Existing collector for redisPoolIdleConns is not a prometheus.Gauge")
-		}
-	})
-	assignOrReuse(m.redisPoolStaleConns, func(ec prometheus.Collector) {
-		if g, ok := ec.(prometheus.Gauge); ok {
-			m.redisPoolStaleConns = g
-		} else {
-			slog.Error("Existing collector for redisPoolStaleConns is not a prometheus.Gauge")
-		}
-	})
-	assignOrReuse(m.redisPoolHits, func(ec prometheus.Collector) {
-		if g, ok := ec.(prometheus.Gauge); ok {
-			m.redisPoolHits = g
-		} else {
-			slog.Error("Existing collector for redisPoolHits is not a prometheus.Gauge")
-		}
-	})
-	assignOrReuse(m.redisPoolMisses, func(ec prometheus.Collector) {
-		if g, ok := ec.(prometheus.Gauge); ok {
-			m.redisPoolMisses = g
-		} else {
-			slog.Error("Existing collector for redisPoolMisses is not a prometheus.Gauge")
-		}
-	})
-	assignOrReuse(m.redisPoolTimeouts, func(ec prometheus.Collector) {
-		if g, ok := ec.(prometheus.Gauge); ok {
-			m.redisPoolTimeouts = g
-		} else {
-			slog.Error("Existing collector for redisPoolTimeouts is not a prometheus.Gauge")
-		}
-	})
+	m.redisPoolTotalConns = registerGauge(reg, m.redisPoolTotalConns)
+	m.redisPoolIdleConns = registerGauge(reg, m.redisPoolIdleConns)
+	m.redisPoolStaleConns = registerGauge(reg, m.redisPoolStaleConns)
+	m.redisPoolHits = registerGauge(reg, m.redisPoolHits)
+	m.redisPoolMisses = registerGauge(reg, m.redisPoolMisses)
+	m.redisPoolTimeouts = registerGauge(reg, m.redisPoolTimeouts)
 
 	return m
 }

--- a/redbench/internal/metrics/metrics.go
+++ b/redbench/internal/metrics/metrics.go
@@ -1,6 +1,7 @@
 package metrics
 
 import (
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -86,10 +87,11 @@ func New(reg prometheus.Registerer, target string) *Metrics {
 		}),
 	}
 
-	// Register metrics, handling duplicates gracefully
+	// Register metrics, handling duplicates gracefully (supporting wrapped errors)
 	assignOrReuse := func(c prometheus.Collector, assign func(prometheus.Collector)) {
 		if err := reg.Register(c); err != nil {
-			if are, ok := err.(prometheus.AlreadyRegisteredError); ok {
+			var are prometheus.AlreadyRegisteredError
+			if errors.As(err, &are) {
 				assign(are.ExistingCollector)
 			} else {
 				slog.Error("Failed to register metric", "error", err)
@@ -99,16 +101,70 @@ func New(reg prometheus.Registerer, target string) *Metrics {
 		}
 	}
 
-	assignOrReuse(m.stage, func(ec prometheus.Collector) { m.stage = ec.(prometheus.Gauge) })
-	assignOrReuse(m.duration, func(ec prometheus.Collector) { m.duration = ec.(*prometheus.HistogramVec) })
-	assignOrReuse(m.requestFailed, func(ec prometheus.Collector) { m.requestFailed = ec.(*prometheus.CounterVec) })
+	assignOrReuse(m.stage, func(ec prometheus.Collector) {
+		if g, ok := ec.(prometheus.Gauge); ok {
+			m.stage = g
+		} else {
+			slog.Error("Existing collector for stage is not a prometheus.Gauge")
+		}
+	})
+	assignOrReuse(m.duration, func(ec prometheus.Collector) {
+		if hv, ok := ec.(*prometheus.HistogramVec); ok {
+			m.duration = hv
+		} else {
+			slog.Error("Existing collector for duration is not a *prometheus.HistogramVec")
+		}
+	})
+	assignOrReuse(m.requestFailed, func(ec prometheus.Collector) {
+		if cv, ok := ec.(*prometheus.CounterVec); ok {
+			m.requestFailed = cv
+		} else {
+			slog.Error("Existing collector for requestFailed is not a *prometheus.CounterVec")
+		}
+	})
 
-	assignOrReuse(m.redisPoolTotalConns, func(ec prometheus.Collector) { m.redisPoolTotalConns = ec.(prometheus.Gauge) })
-	assignOrReuse(m.redisPoolIdleConns, func(ec prometheus.Collector) { m.redisPoolIdleConns = ec.(prometheus.Gauge) })
-	assignOrReuse(m.redisPoolStaleConns, func(ec prometheus.Collector) { m.redisPoolStaleConns = ec.(prometheus.Gauge) })
-	assignOrReuse(m.redisPoolHits, func(ec prometheus.Collector) { m.redisPoolHits = ec.(prometheus.Gauge) })
-	assignOrReuse(m.redisPoolMisses, func(ec prometheus.Collector) { m.redisPoolMisses = ec.(prometheus.Gauge) })
-	assignOrReuse(m.redisPoolTimeouts, func(ec prometheus.Collector) { m.redisPoolTimeouts = ec.(prometheus.Gauge) })
+	assignOrReuse(m.redisPoolTotalConns, func(ec prometheus.Collector) {
+		if g, ok := ec.(prometheus.Gauge); ok {
+			m.redisPoolTotalConns = g
+		} else {
+			slog.Error("Existing collector for redisPoolTotalConns is not a prometheus.Gauge")
+		}
+	})
+	assignOrReuse(m.redisPoolIdleConns, func(ec prometheus.Collector) {
+		if g, ok := ec.(prometheus.Gauge); ok {
+			m.redisPoolIdleConns = g
+		} else {
+			slog.Error("Existing collector for redisPoolIdleConns is not a prometheus.Gauge")
+		}
+	})
+	assignOrReuse(m.redisPoolStaleConns, func(ec prometheus.Collector) {
+		if g, ok := ec.(prometheus.Gauge); ok {
+			m.redisPoolStaleConns = g
+		} else {
+			slog.Error("Existing collector for redisPoolStaleConns is not a prometheus.Gauge")
+		}
+	})
+	assignOrReuse(m.redisPoolHits, func(ec prometheus.Collector) {
+		if g, ok := ec.(prometheus.Gauge); ok {
+			m.redisPoolHits = g
+		} else {
+			slog.Error("Existing collector for redisPoolHits is not a prometheus.Gauge")
+		}
+	})
+	assignOrReuse(m.redisPoolMisses, func(ec prometheus.Collector) {
+		if g, ok := ec.(prometheus.Gauge); ok {
+			m.redisPoolMisses = g
+		} else {
+			slog.Error("Existing collector for redisPoolMisses is not a prometheus.Gauge")
+		}
+	})
+	assignOrReuse(m.redisPoolTimeouts, func(ec prometheus.Collector) {
+		if g, ok := ec.(prometheus.Gauge); ok {
+			m.redisPoolTimeouts = g
+		} else {
+			slog.Error("Existing collector for redisPoolTimeouts is not a prometheus.Gauge")
+		}
+	})
 
 	return m
 }

--- a/redbench/internal/metrics/metrics.go
+++ b/redbench/internal/metrics/metrics.go
@@ -39,7 +39,10 @@ func registerGauge(reg prometheus.Registerer, gauge prometheus.Gauge) prometheus
 			if g, ok := are.ExistingCollector.(prometheus.Gauge); ok {
 				return g
 			}
-			slog.Error("Existing collector is not a prometheus.Gauge")
+			slog.Error("Existing collector is not expected type",
+				"expected", "prometheus.Gauge",
+				"got_type", fmt.Sprintf("%T", are.ExistingCollector),
+			)
 			return nil
 		}
 		slog.Error("Failed to register metric", "error", err)
@@ -59,7 +62,10 @@ func registerHistogram(reg prometheus.Registerer, hv *prometheus.HistogramVec) *
 			if existing, ok := are.ExistingCollector.(*prometheus.HistogramVec); ok {
 				return existing
 			}
-			slog.Error("Existing collector is not a *prometheus.HistogramVec")
+			slog.Error("Existing collector is not expected type",
+				"expected", "*prometheus.HistogramVec",
+				"got_type", fmt.Sprintf("%T", are.ExistingCollector),
+			)
 			return nil
 		}
 		slog.Error("Failed to register metric", "error", err)
@@ -79,7 +85,10 @@ func registerCounter(reg prometheus.Registerer, cv *prometheus.CounterVec) *prom
 			if existing, ok := are.ExistingCollector.(*prometheus.CounterVec); ok {
 				return existing
 			}
-			slog.Error("Existing collector is not a *prometheus.CounterVec")
+			slog.Error("Existing collector is not expected type",
+				"expected", "*prometheus.CounterVec",
+				"got_type", fmt.Sprintf("%T", are.ExistingCollector),
+			)
 			return nil
 		}
 		slog.Error("Failed to register metric", "error", err)

--- a/redbench/internal/metrics/metrics.go
+++ b/redbench/internal/metrics/metrics.go
@@ -29,7 +29,7 @@ type Metrics struct {
 
 // registerGauge registers a Gauge or reuses the existing collector if already registered.
 // Always returns a non-nil Gauge, panicking on a nil input.
-func registerGauge(reg prometheus.Registerer, gauge prometheus.Gauge) prometheus.Gauge {
+func registerGauge(reg prometheus.Registerer, metricName string, gauge prometheus.Gauge) prometheus.Gauge {
 	if gauge == nil {
 		panic("registerGauge: nil gauge provided")
 	}
@@ -40,12 +40,13 @@ func registerGauge(reg prometheus.Registerer, gauge prometheus.Gauge) prometheus
 				return g
 			}
 			slog.Error("Existing collector is not expected type",
+				"metric", metricName,
 				"expected", "prometheus.Gauge",
 				"got_type", fmt.Sprintf("%T", are.ExistingCollector),
 			)
 			return gauge
 		}
-		slog.Error("Failed to register metric", "error", err)
+		slog.Error("Failed to register metric", "metric", metricName, "error", err)
 		return gauge
 	}
 	return gauge
@@ -53,7 +54,7 @@ func registerGauge(reg prometheus.Registerer, gauge prometheus.Gauge) prometheus
 
 // registerHistogram registers a HistogramVec or reuses the existing one.
 // Always returns a non-nil HistogramVec, panicking on a nil input.
-func registerHistogram(reg prometheus.Registerer, hv *prometheus.HistogramVec) *prometheus.HistogramVec {
+func registerHistogram(reg prometheus.Registerer, metricName string, hv *prometheus.HistogramVec) *prometheus.HistogramVec {
 	if hv == nil {
 		panic("registerHistogram: nil HistogramVec provided")
 	}
@@ -64,12 +65,13 @@ func registerHistogram(reg prometheus.Registerer, hv *prometheus.HistogramVec) *
 				return existing
 			}
 			slog.Error("Existing collector is not expected type",
+				"metric", metricName,
 				"expected", "*prometheus.HistogramVec",
 				"got_type", fmt.Sprintf("%T", are.ExistingCollector),
 			)
 			return hv
 		}
-		slog.Error("Failed to register metric", "error", err)
+		slog.Error("Failed to register metric", "metric", metricName, "error", err)
 		return hv
 	}
 	return hv
@@ -77,7 +79,7 @@ func registerHistogram(reg prometheus.Registerer, hv *prometheus.HistogramVec) *
 
 // registerCounter registers a CounterVec or reuses the existing one.
 // Always returns a non-nil CounterVec, panicking on a nil input.
-func registerCounter(reg prometheus.Registerer, cv *prometheus.CounterVec) *prometheus.CounterVec {
+func registerCounter(reg prometheus.Registerer, metricName string, cv *prometheus.CounterVec) *prometheus.CounterVec {
 	if cv == nil {
 		panic("registerCounter: nil CounterVec provided")
 	}
@@ -88,12 +90,13 @@ func registerCounter(reg prometheus.Registerer, cv *prometheus.CounterVec) *prom
 				return existing
 			}
 			slog.Error("Existing collector is not expected type",
+				"metric", metricName,
 				"expected", "*prometheus.CounterVec",
 				"got_type", fmt.Sprintf("%T", are.ExistingCollector),
 			)
 			return cv
 		}
-		slog.Error("Failed to register metric", "error", err)
+		slog.Error("Failed to register metric", "metric", metricName, "error", err)
 		return cv
 	}
 	return cv
@@ -160,16 +163,16 @@ func New(reg prometheus.Registerer, target string) *Metrics {
 	}
 
 	// Register or reuse collectors
-	m.stage = registerGauge(reg, m.stage)
-	m.duration = registerHistogram(reg, m.duration)
-	m.requestFailed = registerCounter(reg, m.requestFailed)
+	m.stage = registerGauge(reg, "stage", m.stage)
+	m.duration = registerHistogram(reg, "request_duration_seconds", m.duration)
+	m.requestFailed = registerCounter(reg, "request_failed_total", m.requestFailed)
 
-	m.redisPoolTotalConns = registerGauge(reg, m.redisPoolTotalConns)
-	m.redisPoolIdleConns = registerGauge(reg, m.redisPoolIdleConns)
-	m.redisPoolStaleConns = registerGauge(reg, m.redisPoolStaleConns)
-	m.redisPoolHits = registerGauge(reg, m.redisPoolHits)
-	m.redisPoolMisses = registerGauge(reg, m.redisPoolMisses)
-	m.redisPoolTimeouts = registerGauge(reg, m.redisPoolTimeouts)
+	m.redisPoolTotalConns = registerGauge(reg, "redis_pool_total_conns", m.redisPoolTotalConns)
+	m.redisPoolIdleConns = registerGauge(reg, "redis_pool_idle_conns", m.redisPoolIdleConns)
+	m.redisPoolStaleConns = registerGauge(reg, "redis_pool_stale_conns", m.redisPoolStaleConns)
+	m.redisPoolHits = registerGauge(reg, "redis_pool_hits", m.redisPoolHits)
+	m.redisPoolMisses = registerGauge(reg, "redis_pool_misses", m.redisPoolMisses)
+	m.redisPoolTimeouts = registerGauge(reg, "redis_pool_timeouts", m.redisPoolTimeouts)
 
 	return m
 }

--- a/redbench/internal/metrics/metrics.go
+++ b/redbench/internal/metrics/metrics.go
@@ -28,10 +28,10 @@ type Metrics struct {
 }
 
 // registerGauge registers a Gauge or reuses the existing collector if already registered.
-// Returns the registered (or reused) Gauge, or nil on failure.
+// Always returns a non-nil Gauge, falling back to the provided one on errors.
 func registerGauge(reg prometheus.Registerer, gauge prometheus.Gauge) prometheus.Gauge {
 	if gauge == nil {
-		return nil
+		return prometheus.NewGauge(prometheus.GaugeOpts{Name: "noop_gauge"})
 	}
 	if err := reg.Register(gauge); err != nil {
 		var are prometheus.AlreadyRegisteredError
@@ -43,18 +43,19 @@ func registerGauge(reg prometheus.Registerer, gauge prometheus.Gauge) prometheus
 				"expected", "prometheus.Gauge",
 				"got_type", fmt.Sprintf("%T", are.ExistingCollector),
 			)
-			return nil
+			return gauge
 		}
 		slog.Error("Failed to register metric", "error", err)
-		return nil
+		return gauge
 	}
 	return gauge
 }
 
-// registerHistogram registers a HistogramVec or reuses the existing one. Returns nil on failure.
+// registerHistogram registers a HistogramVec or reuses the existing one.
+// Always returns a non-nil HistogramVec, falling back to the provided one on errors.
 func registerHistogram(reg prometheus.Registerer, hv *prometheus.HistogramVec) *prometheus.HistogramVec {
 	if hv == nil {
-		return nil
+		return prometheus.NewHistogramVec(prometheus.HistogramOpts{Name: "noop_histogram"}, []string{"noop"})
 	}
 	if err := reg.Register(hv); err != nil {
 		var are prometheus.AlreadyRegisteredError
@@ -66,18 +67,19 @@ func registerHistogram(reg prometheus.Registerer, hv *prometheus.HistogramVec) *
 				"expected", "*prometheus.HistogramVec",
 				"got_type", fmt.Sprintf("%T", are.ExistingCollector),
 			)
-			return nil
+			return hv
 		}
 		slog.Error("Failed to register metric", "error", err)
-		return nil
+		return hv
 	}
 	return hv
 }
 
-// registerCounter registers a CounterVec or reuses the existing one. Returns nil on failure.
+// registerCounter registers a CounterVec or reuses the existing one.
+// Always returns a non-nil CounterVec, falling back to the provided one on errors.
 func registerCounter(reg prometheus.Registerer, cv *prometheus.CounterVec) *prometheus.CounterVec {
 	if cv == nil {
-		return nil
+		return prometheus.NewCounterVec(prometheus.CounterOpts{Name: "noop_counter"}, []string{"noop"})
 	}
 	if err := reg.Register(cv); err != nil {
 		var are prometheus.AlreadyRegisteredError
@@ -89,10 +91,10 @@ func registerCounter(reg prometheus.Registerer, cv *prometheus.CounterVec) *prom
 				"expected", "*prometheus.CounterVec",
 				"got_type", fmt.Sprintf("%T", are.ExistingCollector),
 			)
-			return nil
+			return cv
 		}
 		slog.Error("Failed to register metric", "error", err)
-		return nil
+		return cv
 	}
 	return cv
 }

--- a/redbench/internal/metrics/metrics_test.go
+++ b/redbench/internal/metrics/metrics_test.go
@@ -85,6 +85,30 @@ func TestUpdateRedisPoolStats(t *testing.T) {
 	// Skip nil test as it's not handled in the implementation
 }
 
+// Verifies that metrics are still updated when a second start occurs (duplicate registration case).
+func TestUpdateRedisPoolStats_AfterSecondStart(t *testing.T) {
+	reg := prometheus.NewRegistry()
+
+	// First start for target
+	m1 := New(reg, "repeat-target")
+	stats1 := &redis.PoolStats{TotalConns: 5, IdleConns: 2, StaleConns: 1, Hits: 10, Misses: 1, Timeouts: 0}
+	m1.UpdateRedisPoolStats(stats1)
+
+	// Second start for the same target (duplicate registration internally handled)
+	m2 := New(reg, "repeat-target")
+	stats2 := &redis.PoolStats{TotalConns: 7, IdleConns: 3, StaleConns: 2, Hits: 20, Misses: 2, Timeouts: 1}
+	m2.UpdateRedisPoolStats(stats2)
+
+	// Expose metrics and ensure endpoint is healthy (values presence is implicitly verified by scrape success)
+	server := httptest.NewServer(promhttp.HandlerFor(reg, promhttp.HandlerOpts{}))
+	defer server.Close()
+
+	resp, err := http.Get(server.URL)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+}
+
 func TestSetStage(t *testing.T) {
 	reg := prometheus.NewRegistry()
 	m := New(reg, "test-target")

--- a/redbench/test/integration/metrics_integration_test.go
+++ b/redbench/test/integration/metrics_integration_test.go
@@ -103,8 +103,7 @@ func stopIfRunning(t *testing.T, baseURL string) error {
 	if err != nil {
 		return err
 	}
-	io.Copy(io.Discard, resp.Body)
-	resp.Body.Close()
+	defer resp.Body.Close()
 	return nil
 }
 

--- a/redbench/test/integration/metrics_integration_test.go
+++ b/redbench/test/integration/metrics_integration_test.go
@@ -1,0 +1,127 @@
+package integration
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/simonasr/benchmarketing/redbench/internal/config"
+	"github.com/simonasr/benchmarketing/redbench/internal/service"
+)
+
+// TestServiceMetricsPersistAndUpdateAcrossRestarts validates that Redis request metrics
+// continue to be exposed and increase when starting a job a second time.
+func TestServiceMetricsPersistAndUpdateAcrossRestarts(t *testing.T) {
+	mockRedis := miniredis.RunT(t)
+
+	cfg, err := config.LoadConfig("../../config.yaml")
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+	ConfigureQuickBenchmark(cfg)
+
+	redisConn := &config.RedisConnection{
+		URL:         fmt.Sprintf("redis://%s", mockRedis.Addr()),
+		TargetLabel: TestRedisLabel,
+	}
+
+	reg := prometheus.NewRegistry()
+	port := ServiceLifecyclePort + 1 // avoid collision with other tests
+	server := service.NewServer(port, cfg, redisConn, reg)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	go func() { _ = server.Start(ctx) }()
+	time.Sleep(StartupDelay)
+
+	baseURL := fmt.Sprintf("http://localhost:%d", port)
+
+	// Helper to start a short benchmark run
+	startOnce := func() {
+		startReq := map[string]any{
+			"config": map[string]any{
+				"test": map[string]any{
+					"minClients":      1,
+					"maxClients":      2,
+					"stageIntervalMs": TestStageIntervalFast,
+					"requestDelayMs":  TestRequestDelayNormal,
+					"keySize":         TestKeySize,
+					"valueSize":       TestValueSizeSmall,
+				},
+			},
+			"redis": map[string]any{
+				"url":         fmt.Sprintf("redis://%s", mockRedis.Addr()),
+				"targetLabel": TestRedisLabel,
+			},
+		}
+		b, _ := json.Marshal(startReq)
+		resp, err := http.Post(baseURL+"/start", "application/json", bytes.NewBuffer(b))
+		if err != nil {
+			t.Fatalf("start: %v", err)
+		}
+		resp.Body.Close()
+		if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
+			t.Fatalf("unexpected start status: %d", resp.StatusCode)
+		}
+	}
+
+	// First start
+	startOnce()
+	time.Sleep(ServiceRunDuration)
+	expectedTarget := fmt.Sprintf("redis://%s", mockRedis.Addr())
+	c1 := scrapeSetCount(t, baseURL+"/metrics", expectedTarget)
+
+	// Stop if running
+	_ = stopIfRunning(t, baseURL)
+	time.Sleep(ShutdownDelay)
+
+	// Second start
+	startOnce()
+	time.Sleep(ServiceRunDuration)
+	c2 := scrapeSetCount(t, baseURL+"/metrics", expectedTarget)
+
+	if c2 <= c1 {
+		t.Fatalf("expected set count to increase across second start; got first=%d second=%d", c1, c2)
+	}
+
+	cancel()
+}
+
+func stopIfRunning(t *testing.T, baseURL string) error {
+	t.Helper()
+	req, _ := http.NewRequest(http.MethodDelete, baseURL+"/stop", nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	io.Copy(io.Discard, resp.Body)
+	resp.Body.Close()
+	return nil
+}
+
+func scrapeSetCount(t *testing.T, metricsURL string, target string) int {
+	t.Helper()
+	resp, err := http.Get(metricsURL)
+	if err != nil {
+		t.Fatalf("scrape metrics: %v", err)
+	}
+	defer resp.Body.Close()
+	b, _ := io.ReadAll(resp.Body)
+	// Match redbench_request_duration_seconds_count with command="set" and target label
+	re := regexp.MustCompile(`redbench_request_duration_seconds_count\{[^}]*command="set"[^}]*target="` + regexp.QuoteMeta(target) + `"[^}]*\}\s+(\d+)`)
+	m := re.FindSubmatch(b)
+	if len(m) < 2 {
+		t.Fatalf("did not find set count metric for target %s", target)
+	}
+	var n int
+	fmt.Sscanf(string(m[1]), "%d", &n)
+	return n
+}

--- a/redbench/test/integration/metrics_integration_test.go
+++ b/redbench/test/integration/metrics_integration_test.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"net/http"
 	"regexp"
-	"sync"
 	"testing"
 	"time"
 
@@ -128,14 +127,7 @@ func scrapeSetCount(t *testing.T, metricsURL string, target string) int {
 	return n
 }
 
-var setCountReCache sync.Map // map[string]*regexp.Regexp
-
 func getSetCountRegex(target string) *regexp.Regexp {
-	if v, ok := setCountReCache.Load(target); ok {
-		return v.(*regexp.Regexp)
-	}
 	pattern := `redbench_request_duration_seconds_count\{[^}]*command="set"[^}]*target="` + regexp.QuoteMeta(target) + `"[^}]*\}\s+(\d+)`
-	re := regexp.MustCompile(pattern)
-	setCountReCache.Store(target, re)
-	return re
+	return regexp.MustCompile(pattern)
 }

--- a/redbench/test/integration/metrics_integration_test.go
+++ b/redbench/test/integration/metrics_integration_test.go
@@ -122,6 +122,8 @@ func scrapeSetCount(t *testing.T, metricsURL string, target string) int {
 		t.Fatalf("did not find set count metric for target %s", target)
 	}
 	var n int
-	fmt.Sscanf(string(m[1]), "%d", &n)
+	if _, err := fmt.Sscanf(string(m[1]), "%d", &n); err != nil {
+		t.Fatalf("parse metric value: %v", err)
+	}
 	return n
 }

--- a/redbench/test/integration/metrics_integration_test.go
+++ b/redbench/test/integration/metrics_integration_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"regexp"
+	"sync"
 	"testing"
 	"time"
 
@@ -116,7 +117,7 @@ func scrapeSetCount(t *testing.T, metricsURL string, target string) int {
 	defer resp.Body.Close()
 	b, _ := io.ReadAll(resp.Body)
 	// Match redbench_request_duration_seconds_count with command="set" and target label
-	re := regexp.MustCompile(`redbench_request_duration_seconds_count\{[^}]*command="set"[^}]*target="` + regexp.QuoteMeta(target) + `"[^}]*\}\s+(\d+)`)
+	re := getSetCountRegex(target)
 	m := re.FindSubmatch(b)
 	if len(m) < 2 {
 		t.Fatalf("did not find set count metric for target %s", target)
@@ -126,4 +127,16 @@ func scrapeSetCount(t *testing.T, metricsURL string, target string) int {
 		t.Fatalf("parse metric value: %v", err)
 	}
 	return n
+}
+
+var setCountReCache sync.Map // map[string]*regexp.Regexp
+
+func getSetCountRegex(target string) *regexp.Regexp {
+	if v, ok := setCountReCache.Load(target); ok {
+		return v.(*regexp.Regexp)
+	}
+	pattern := `redbench_request_duration_seconds_count\{[^}]*command="set"[^}]*target="` + regexp.QuoteMeta(target) + `"[^}]*\}\s+(\d+)`
+	re := regexp.MustCompile(pattern)
+	setCountReCache.Store(target, re)
+	return re
 }

--- a/redbench/test/integration/metrics_integration_test.go
+++ b/redbench/test/integration/metrics_integration_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"regexp"
+	"strconv"
 	"testing"
 	"time"
 
@@ -120,8 +121,8 @@ func scrapeSetCount(t *testing.T, metricsURL string, target string) int {
 	if len(m) < 2 {
 		t.Fatalf("did not find set count metric for target %s", target)
 	}
-	var n int
-	if _, err := fmt.Sscanf(string(m[1]), "%d", &n); err != nil {
+	n, err := strconv.Atoi(string(m[1]))
+	if err != nil {
 		t.Fatalf("parse metric value: %v", err)
 	}
 	return n


### PR DESCRIPTION
This PR fixes a metrics registration issue where metrics were not properly updated when jobs were restarted. The fix ensures that when metrics are already registered in the Prometheus registry, the existing collectors are reused rather than ignored, allowing metrics to continue accumulating across job restarts.

- Introduces robust metric registration helpers that handle duplicate registrations gracefully
- Replaces the previous registration approach that silently ignored already-registered metrics
- Adds comprehensive integration and unit tests to verify metrics persistence across restarts