### PR TITLE
redbench: add worker connect retry

### DIFF
--- a/redbench/internal/worker/worker.go
+++ b/redbench/internal/worker/worker.go
@@ -11,6 +11,7 @@ import (
 	"os/signal"
 	"strings"
 	"syscall"
+	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 
@@ -25,6 +26,17 @@ type Worker struct {
 	workerID  string
 	port      int
 }
+
+// Retry configuration for worker registration
+const (
+	registrationMaxAttempts       = 5
+	registrationInitialBackoff    = 200 * time.Millisecond
+	registrationMaxBackoff        = 1600 * time.Millisecond
+	registrationBackoffMultiplier = 2
+)
+
+// Periodic re-registration interval (variable to allow test override)
+var registrationRefreshInterval = 10 * time.Second
 
 // NewWorker creates a new worker instance.
 func NewWorker(cfg *config.Config, redisConn *config.RedisConnection, port int, controllerURL string, bindAddress string, reg *prometheus.Registry) (*Worker, error) {
@@ -88,9 +100,9 @@ func NewWorker(cfg *config.Config, redisConn *config.RedisConnection, port int, 
 func (w *Worker) Start(ctx context.Context) error {
 	slog.Info("Starting worker", "worker_id", w.workerID, "port", w.port)
 
-	// Register with controller
-	if err := w.regClient.Register(); err != nil {
-		return fmt.Errorf("failed to register with controller: %w", err)
+	// Register with controller (simple retry with exponential backoff)
+	if err := w.registerWithRetry(ctx); err != nil {
+		return err
 	}
 
 	// Set up graceful shutdown with unregistration
@@ -116,12 +128,55 @@ func (w *Worker) Start(ctx context.Context) error {
 		cancel()
 	}()
 
+	// Periodic re-registration loop to survive controller restarts
+	go func(parentCtx context.Context) {
+		ticker := time.NewTicker(registrationRefreshInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-parentCtx.Done():
+				return
+			case <-ticker.C:
+				if err := w.registerWithRetry(parentCtx); err != nil {
+					slog.Warn("Periodic re-registration failed", "error", err)
+				}
+			}
+		}
+	}(ctx)
+
 	// Start the service server (this will block until shutdown)
 	if err := w.server.Start(ctx); err != nil {
 		return fmt.Errorf("worker server failed: %w", err)
 	}
 
 	slog.Info("Worker shutdown complete", "worker_id", w.workerID)
+	return nil
+}
+
+// registerWithRetry performs registration with retry/backoff respecting the context.
+func (w *Worker) registerWithRetry(ctx context.Context) error {
+	backoff := registrationInitialBackoff
+	for attempt := 1; attempt <= registrationMaxAttempts; attempt++ {
+		if err := w.regClient.Register(); err != nil {
+			// Abort if context is done
+			select {
+			case <-ctx.Done():
+				return fmt.Errorf("failed to register with controller: %w", err)
+			default:
+			}
+
+			if attempt == registrationMaxAttempts {
+				return fmt.Errorf("failed to register with controller: %w", err)
+			}
+			slog.Warn("Registration failed, retrying", "attempt", attempt, "max_attempts", registrationMaxAttempts, "error", err)
+			time.Sleep(backoff)
+			if backoff < registrationMaxBackoff {
+				backoff = backoff * registrationBackoffMultiplier
+			}
+			continue
+		}
+		break
+	}
 	return nil
 }
 

--- a/redbench/internal/worker/worker.go
+++ b/redbench/internal/worker/worker.go
@@ -169,9 +169,23 @@ func (w *Worker) registerWithRetry(ctx context.Context) error {
 				return fmt.Errorf("failed to register with controller: %w", err)
 			}
 			slog.Warn("Registration failed, retrying", "attempt", attempt, "max_attempts", registrationMaxAttempts, "error", err)
-			time.Sleep(backoff)
+			// Context-aware wait for backoff
+			timer := time.NewTimer(backoff)
+			select {
+			case <-ctx.Done():
+				if !timer.Stop() {
+					<-timer.C
+				}
+				return fmt.Errorf("failed to register with controller: %w", err)
+			case <-timer.C:
+			}
 			if backoff < registrationMaxBackoff {
-				backoff = backoff * registrationBackoffMultiplier
+				next := backoff * registrationBackoffMultiplier
+				if next > registrationMaxBackoff {
+					backoff = registrationMaxBackoff
+				} else {
+					backoff = next
+				}
 			}
 			continue
 		}

--- a/redbench/internal/worker/worker.go
+++ b/redbench/internal/worker/worker.go
@@ -171,15 +171,9 @@ func (w *Worker) registerWithRetry(ctx context.Context) error {
 			slog.Warn("Registration failed, retrying", "attempt", attempt, "max_attempts", registrationMaxAttempts, "error", err)
 			// Context-aware wait for backoff
 			timer := time.NewTimer(backoff)
+			defer timer.Stop()
 			select {
 			case <-ctx.Done():
-				if !timer.Stop() {
-					// Non-blocking drain to avoid potential blocking if already fired
-					select {
-					case <-timer.C:
-					default:
-					}
-				}
 				return fmt.Errorf("registration cancelled due to context: %w", ctx.Err())
 			case <-timer.C:
 			}
@@ -193,7 +187,7 @@ func (w *Worker) registerWithRetry(ctx context.Context) error {
 			}
 			continue
 		}
-		break
+		return nil
 	}
 	return nil
 }

--- a/redbench/internal/worker/worker.go
+++ b/redbench/internal/worker/worker.go
@@ -161,7 +161,7 @@ func (w *Worker) registerWithRetry(ctx context.Context) error {
 			// Abort if context is done
 			select {
 			case <-ctx.Done():
-				return fmt.Errorf("failed to register with controller: %w", err)
+				return fmt.Errorf("registration cancelled due to context: %w", ctx.Err())
 			default:
 			}
 
@@ -174,9 +174,13 @@ func (w *Worker) registerWithRetry(ctx context.Context) error {
 			select {
 			case <-ctx.Done():
 				if !timer.Stop() {
-					<-timer.C
+					// Non-blocking drain to avoid potential blocking if already fired
+					select {
+					case <-timer.C:
+					default:
+					}
 				}
-				return fmt.Errorf("failed to register with controller: %w", err)
+				return fmt.Errorf("registration cancelled due to context: %w", ctx.Err())
 			case <-timer.C:
 			}
 			if backoff < registrationMaxBackoff {

--- a/redbench/internal/worker/worker.go
+++ b/redbench/internal/worker/worker.go
@@ -171,12 +171,13 @@ func (w *Worker) registerWithRetry(ctx context.Context) error {
 			slog.Warn("Registration failed, retrying", "attempt", attempt, "max_attempts", registrationMaxAttempts, "error", err)
 			// Context-aware wait for backoff
 			timer := time.NewTimer(backoff)
-			defer timer.Stop()
 			select {
 			case <-ctx.Done():
+				timer.Stop()
 				return fmt.Errorf("registration cancelled due to context: %w", ctx.Err())
 			case <-timer.C:
 			}
+			timer.Stop()
 			if backoff < registrationMaxBackoff {
 				next := backoff * registrationBackoffMultiplier
 				if next > registrationMaxBackoff {
@@ -189,7 +190,8 @@ func (w *Worker) registerWithRetry(ctx context.Context) error {
 		}
 		return nil
 	}
-	return nil
+	// Defensive return: linter cannot prove all paths return
+	return fmt.Errorf("failed to register with controller: exceeded max attempts")
 }
 
 // resolveWorkerAddress determines the appropriate address for worker registration.

--- a/redbench/internal/worker/worker_test.go
+++ b/redbench/internal/worker/worker_test.go
@@ -212,6 +212,87 @@ func TestWorkerStartRegistrationFailure(t *testing.T) {
 	}
 }
 
+func TestWorkerStartRegistrationRetryThenSuccess(t *testing.T) {
+	// Controller returns 500 twice, then 201
+	attempt := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost && r.URL.Path == "/workers/register" {
+			attempt++
+			if attempt < 3 {
+				w.WriteHeader(http.StatusInternalServerError)
+				w.Write([]byte(`{"error":"temporary"}`))
+				return
+			}
+			w.WriteHeader(http.StatusCreated)
+			w.Write([]byte(`{"status":"registered"}`))
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	cfg := &config.Config{Controller: config.ControllerConfig{HTTPTimeoutMs: 1000}}
+	redisConn := &config.RedisConnection{URL: "redis://localhost:6379"}
+	reg := prometheus.NewRegistry()
+
+	worker, err := NewWorker(cfg, redisConn, 8080, server.URL, "", reg)
+	if err != nil {
+		t.Fatalf("Failed to create worker: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	err = worker.Start(ctx)
+	if err != nil {
+		t.Fatalf("Expected success after retries, got error: %v", err)
+	}
+
+	if attempt != 3 {
+		t.Fatalf("Expected 3 registration attempts, got %d", attempt)
+	}
+}
+
+func TestPeriodicReregistration(t *testing.T) {
+	// Speed up the ticker for test
+	old := registrationRefreshInterval
+	registrationRefreshInterval = 100 * time.Millisecond
+	defer func() { registrationRefreshInterval = old }()
+
+	regCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost && r.URL.Path == "/workers/register" {
+			regCount++
+			w.WriteHeader(http.StatusCreated)
+			w.Write([]byte(`{"status":"registered"}`))
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	cfg := &config.Config{Controller: config.ControllerConfig{HTTPTimeoutMs: 500}}
+	redisConn := &config.RedisConnection{URL: "redis://localhost:6379"}
+	reg := prometheus.NewRegistry()
+
+	worker, err := NewWorker(cfg, redisConn, 8080, server.URL, "", reg)
+	if err != nil {
+		t.Fatalf("Failed to create worker: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 350*time.Millisecond)
+	defer cancel()
+
+	if err := worker.Start(ctx); err != nil {
+		t.Fatalf("worker.Start error: %v", err)
+	}
+
+	// On start, it registers once, plus ~3 ticks
+	if regCount < 3 {
+		t.Fatalf("expected multiple registrations, got %d", regCount)
+	}
+}
+
 func TestWorkerStartControllerUnavailable(t *testing.T) {
 	cfg := &config.Config{}
 	redisConn := &config.RedisConnection{URL: "redis://localhost:6379"}


### PR DESCRIPTION
This PR adds worker connection retry functionality to the redbench system by implementing exponential backoff for worker registration with the controller and periodic re-registration to handle controller restarts.

- Implements retry logic with exponential backoff for worker registration attempts
- Adds periodic re-registration to survive controller restarts
- Includes comprehensive test coverage for both retry scenarios and periodic registration