### PR TITLE
redbench: unify redis cluster parameter

### DIFF
--- a/redbench/CONTROLLER_USAGE.md
+++ b/redbench/CONTROLLER_USAGE.md
@@ -78,7 +78,7 @@ curl -X POST http://localhost:8081/job/start \
         "workerCount": 2
       },
       {
-        "redisClusterUrl": "rediss://redis-cluster.example.com:6380",
+        "clusterUrl": "rediss://redis-cluster.example.com:6380",
         "workerCount": 2
       }
     ],
@@ -100,7 +100,7 @@ curl -X POST http://localhost:8081/job/start \
 ```
 
 - Use `redisUrl` for a single Redis instance.
-- Use `redisClusterUrl` for Redis Cluster; both `redis://` and `rediss://` schemes are accepted. When a full URL is provided, the controller extracts the host:port for cluster clients while preserving TLS intent.
+- Use `clusterUrl` for Redis Cluster; both `redis://` and `rediss://` schemes are accepted. When a full URL is provided, the controller extracts the host:port for cluster clients while preserving TLS intent.
 - Redis behavior overrides can be provided under `config.redis`:
   - `operationTimeoutMs`: per-operation timeout in milliseconds
   - `expiration`: TTL for generated keys in seconds
@@ -150,7 +150,11 @@ curl http://localhost:8081/job/status
       "workerCount": 3
     },
     {
-      "redisClusterUrl": "rediss://redis-cluster-2.example.com:6380",
+      "clusterUrl": "rediss://redis-cluster-2.example.com:6380",
+      "workerCount": 2
+    }
+    {
+      "clusterUrl": "rediss://redis-cluster-2.example.com:6380",
       "workerCount": 2
     }
   ],

--- a/redbench/internal/controller/job_manager.go
+++ b/redbench/internal/controller/job_manager.go
@@ -337,14 +337,14 @@ func (jm *JobManager) ListJobs() []*Job {
 
 // parseRedisTarget creates a RedisConnection from a job target
 func (jm *JobManager) parseRedisTarget(target JobTarget) (*config.RedisConnection, error) {
-	if target.RedisClusterURL == "" && target.RedisURL == "" {
-		return nil, fmt.Errorf("either redisClusterUrl or redisUrl must be provided")
+	if target.ClusterURL == "" && target.RedisURL == "" {
+		return nil, fmt.Errorf("either clusterUrl or redisUrl must be provided")
 	}
 	conn := &config.RedisConnection{}
-	if target.RedisClusterURL != "" {
-		conn.ClusterURL = target.RedisClusterURL
+	if target.ClusterURL != "" {
+		conn.ClusterURL = target.ClusterURL
 		if err := conn.ParseClusterURL(); err != nil {
-			return nil, fmt.Errorf("parsing cluster URL %s: %w", target.RedisClusterURL, err)
+			return nil, fmt.Errorf("parsing cluster URL %s: %w", target.ClusterURL, err)
 		}
 	} else {
 		conn.URL = target.RedisURL
@@ -357,8 +357,8 @@ func (jm *JobManager) parseRedisTarget(target JobTarget) (*config.RedisConnectio
 }
 
 func (jm *JobManager) targetLabelFor(target JobTarget) string {
-	if target.RedisClusterURL != "" {
-		return target.RedisClusterURL
+	if target.ClusterURL != "" {
+		return target.ClusterURL
 	}
 	return target.RedisURL
 }

--- a/redbench/internal/controller/job_manager_test.go
+++ b/redbench/internal/controller/job_manager_test.go
@@ -93,7 +93,7 @@ func TestCreateJob(t *testing.T) {
 				},
 			},
 			wantErr: true,
-			errMsg:  "invalid Redis target: either redisClusterUrl or redisUrl must be provided",
+			errMsg:  "invalid Redis target: either clusterUrl or redisUrl must be provided",
 		},
 	}
 
@@ -404,7 +404,7 @@ func TestParseRedisTarget(t *testing.T) {
 		},
 		{
 			name:       "valid cluster URL",
-			target:     JobTarget{RedisClusterURL: "redis://cluster.example.com:6379"},
+			target:     JobTarget{ClusterURL: "redis://cluster.example.com:6379"},
 			wantErr:    false,
 			expectURL:  "",
 			expectCURL: "cluster.example.com:6379", // ParseClusterURL strips scheme to host:port

--- a/redbench/internal/controller/types.go
+++ b/redbench/internal/controller/types.go
@@ -39,9 +39,9 @@ const (
 
 // JobTarget represents a Redis target assignment for workers.
 type JobTarget struct {
-	RedisURL        string `json:"redisUrl"`
-	RedisClusterURL string `json:"redisClusterUrl,omitempty"`
-	WorkerCount     int    `json:"workerCount"`
+	RedisURL    string `json:"redisUrl"`
+	ClusterURL  string `json:"clusterUrl,omitempty"`
+	WorkerCount int    `json:"workerCount"`
 }
 
 // JobRequest represents a request to start a coordinated benchmark job.

--- a/redbench/internal/controller/ui/app.js
+++ b/redbench/internal/controller/ui/app.js
@@ -167,10 +167,10 @@ function serializeJobForm() {
   const targets = [];
   document.querySelectorAll('#targets .target').forEach(t => {
     const redisUrl = t.querySelector('input[name="redisUrl"]').value.trim();
-    const redisClusterUrl = t.querySelector('input[name="redisClusterUrl"]').value.trim();
+    const clusterUrl = t.querySelector('input[name="clusterUrl"]').value.trim();
     const workerCount = parseInt(t.querySelector('input[name="workerCount"]').value, 10) || 1;
-    if (!redisUrl && !redisClusterUrl) return;
-    targets.push({ redisUrl, redisClusterUrl, workerCount });
+    if (!redisUrl && !clusterUrl) return;
+    targets.push({ redisUrl, clusterUrl, workerCount });
   });
 
   const config = {
@@ -338,7 +338,7 @@ function snapshotForm() {
   document.querySelectorAll('#targets .target').forEach(t => {
     targets.push({
       redisUrl: t.querySelector('input[name="redisUrl"]').value.trim(),
-      redisClusterUrl: t.querySelector('input[name="redisClusterUrl"]').value.trim(),
+      clusterUrl: t.querySelector('input[name="clusterUrl"]').value.trim(),
       workerCount: t.querySelector('input[name="workerCount"]').value.trim(),
     });
   });
@@ -375,7 +375,7 @@ function restoreForm(data) {
   data.targets.forEach((t, i) => {
     const row = getOrCreateRow(i);
     row.querySelector('input[name="redisUrl"]').value = t.redisUrl || '';
-    row.querySelector('input[name="redisClusterUrl"]').value = t.redisClusterUrl || '';
+    row.querySelector('input[name="clusterUrl"]').value = (t.clusterUrl || '') ;
     row.querySelector('input[name="workerCount"]').value = t.workerCount || '1';
   });
   const set = (id, val) => { const el = document.getElementById(id); if (el && val != null) el.value = val; };
@@ -426,7 +426,7 @@ function initReset() {
     rows.forEach((row, i) => { if (i) row.remove(); });
     const first = container.querySelector('.target');
     first.querySelector('input[name="redisUrl"]').value = '';
-    first.querySelector('input[name="redisClusterUrl"]').value = '';
+    first.querySelector('input[name="clusterUrl"]').value = '';
     first.querySelector('input[name="workerCount"]').value = '1';
     setStatus('Form reset to defaults.', 'success');
   });

--- a/redbench/internal/controller/ui/index.html
+++ b/redbench/internal/controller/ui/index.html
@@ -32,7 +32,7 @@
                   <input type="text" name="redisUrl" placeholder="redis://host:6379 or rediss://...">
                 </label>
                 <label>Cluster URL
-                  <input type="text" name="redisClusterUrl" placeholder="rediss://cluster:6380 or host:port">
+                  <input type="text" name="clusterUrl" placeholder="rediss://cluster:6380 or host:port">
                 </label>
                 <label>Worker Count
                   <input type="number" name="workerCount" value="1" min="1">

--- a/redbench/test/integration/controller_worker_test.go
+++ b/redbench/test/integration/controller_worker_test.go
@@ -137,8 +137,8 @@ func TestControllerWorkerIntegration(t *testing.T) {
 	clusterReq := map[string]interface{}{
 		"targets": []map[string]interface{}{
 			{
-				"redisClusterUrl": "redis://localhost:6379",
-				"workerCount":     1,
+				"clusterUrl":  "redis://localhost:6379",
+				"workerCount": 1,
 			},
 		},
 	}


### PR DESCRIPTION
This PR standardizes the Redis cluster parameter name from `redisClusterUrl` to `clusterUrl` across the redbench codebase for consistency.

- Updates all references from `redisClusterUrl` to `clusterUrl` in Go structs, JavaScript, HTML, and documentation
- Maintains the same functionality while providing a more concise parameter name
- Updates error messages and test cases to reflect the new parameter name
