### PR TITLE
ui: rename Restart -> Exit

### DIFF
--- a/redbench/internal/controller/ui/app.js
+++ b/redbench/internal/controller/ui/app.js
@@ -152,7 +152,7 @@ async function loadWorkers() {
         el('td', { text: new Date(w.lastSeen).toLocaleString() }),
         el('td', { text: w.currentJob || '' }),
         el('td', {}, (() => {
-          const btn = el('button', { class: 'exitWorker', 'data-worker-id': w.id }, 'Restart');
+          const btn = el('button', { class: 'exitWorker', 'data-worker-id': w.id }, 'Exit');
           btn.disabled = w.status === 'busy';
           return btn;
         })()),


### PR DESCRIPTION
This PR renames the button text from "Restart" to "Exit" in the worker management UI to better reflect the button's actual functionality.

- Updates button text to accurately represent the action performed on workers