### PR TITLE
redbench: limit one job per controller

### DIFF
--- a/redbench/internal/controller/handlers.go
+++ b/redbench/internal/controller/handlers.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -215,12 +216,22 @@ func (c *Controller) StartJobHandler(w http.ResponseWriter, r *http.Request) {
 	// Create the job
 	job, err := c.jobManager.CreateJob(req)
 	if err != nil {
+		if errors.Is(err, ErrJobAlreadyRunning) {
+			slog.Warn("Job creation rejected: another job is running", "error", err)
+			http.Error(w, "Another job is already running", http.StatusConflict)
+			return
+		}
 		logAndRespond(w, "Failed to create job", err, fmt.Sprintf("Job creation failed: %v", err))
 		return
 	}
 
 	// Start the job
 	if err := c.jobManager.StartJob(job.ID); err != nil {
+		if errors.Is(err, ErrJobAlreadyRunning) {
+			slog.Warn("Job start rejected: another job is running", "error", err)
+			http.Error(w, "Another job is already running", http.StatusConflict)
+			return
+		}
 		logAndRespond(w, "Failed to start job", err, fmt.Sprintf("Job start failed: %v", err))
 		return
 	}

--- a/redbench/internal/controller/job_manager.go
+++ b/redbench/internal/controller/job_manager.go
@@ -3,6 +3,7 @@ package controller
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -22,6 +23,9 @@ type JobManager struct {
 	config     *config.Config
 }
 
+// ErrJobAlreadyRunning indicates an attempt to create/start a job while another is running.
+var ErrJobAlreadyRunning = errors.New("another job is already running")
+
 // NewJobManager creates a new job manager.
 func NewJobManager(registry *Registry, cfg *config.Config) *JobManager {
 	return &JobManager{
@@ -35,6 +39,13 @@ func NewJobManager(registry *Registry, cfg *config.Config) *JobManager {
 func (jm *JobManager) CreateJob(req JobRequest) (*Job, error) {
 	jm.mu.Lock()
 	defer jm.mu.Unlock()
+
+	// Enforce single running job at a time
+	for _, existing := range jm.jobs {
+		if existing.Status == JobStatusRunning {
+			return nil, fmt.Errorf("%w: %s", ErrJobAlreadyRunning, existing.ID)
+		}
+	}
 
 	// Calculate total workers needed
 	totalWorkersNeeded := 0
@@ -101,6 +112,13 @@ func (jm *JobManager) CreateJob(req JobRequest) (*Job, error) {
 func (jm *JobManager) StartJob(jobID string) error {
 	jm.mu.Lock()
 	defer jm.mu.Unlock()
+
+	// Defensive single-job enforcement: prevent starting if another is running
+	for id, existing := range jm.jobs {
+		if id != jobID && existing.Status == JobStatusRunning {
+			return fmt.Errorf("%w: %s", ErrJobAlreadyRunning, existing.ID)
+		}
+	}
 
 	job, exists := jm.jobs[jobID]
 	if !exists {

--- a/redbench/internal/controller/job_manager.go
+++ b/redbench/internal/controller/job_manager.go
@@ -35,16 +35,25 @@ func NewJobManager(registry *Registry, cfg *config.Config) *JobManager {
 	}
 }
 
+// hasRunningJob reports if there is a running job in the manager.
+// If excludeID is non-empty, that job ID will be ignored when checking.
+func (jm *JobManager) hasRunningJob(excludeID string) (bool, string) {
+	for id, j := range jm.jobs {
+		if id != excludeID && j.Status == JobStatusRunning {
+			return true, id
+		}
+	}
+	return false, ""
+}
+
 // CreateJob creates a new coordinated benchmark job.
 func (jm *JobManager) CreateJob(req JobRequest) (*Job, error) {
 	jm.mu.Lock()
 	defer jm.mu.Unlock()
 
 	// Enforce single running job at a time
-	for _, existing := range jm.jobs {
-		if existing.Status == JobStatusRunning {
-			return nil, fmt.Errorf("%w: %s", ErrJobAlreadyRunning, existing.ID)
-		}
+	if ok, runningID := jm.hasRunningJob(""); ok {
+		return nil, fmt.Errorf("%w: %s", ErrJobAlreadyRunning, runningID)
 	}
 
 	// Calculate total workers needed
@@ -113,16 +122,14 @@ func (jm *JobManager) StartJob(jobID string) error {
 	jm.mu.Lock()
 	defer jm.mu.Unlock()
 
-	// Defensive single-job enforcement: prevent starting if another is running
-	for id, existing := range jm.jobs {
-		if id != jobID && existing.Status == JobStatusRunning {
-			return fmt.Errorf("%w: %s", ErrJobAlreadyRunning, existing.ID)
-		}
-	}
-
 	job, exists := jm.jobs[jobID]
 	if !exists {
 		return fmt.Errorf("job %s not found", jobID)
+	}
+
+	// Defensive single-job enforcement: prevent starting if another is running
+	if ok, runningID := jm.hasRunningJob(jobID); ok {
+		return fmt.Errorf("%w: %s", ErrJobAlreadyRunning, runningID)
 	}
 
 	if job.Status != JobStatusPending {

--- a/redbench/internal/controller/job_manager_test.go
+++ b/redbench/internal/controller/job_manager_test.go
@@ -1,7 +1,9 @@
 package controller
 
 import (
+	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -539,6 +541,40 @@ func TestJobWorkflow(t *testing.T) {
 	}
 }
 
+func TestCreateJob_RejectsWhenJobAlreadyRunning(t *testing.T) {
+	registry := NewRegistry()
+	cfg := &config.Config{Controller: config.LoadControllerConfig()}
+	jm := NewJobManager(registry, cfg)
+
+	// Register a single worker
+	if err := registry.RegisterWorker(RegistrationRequest{WorkerID: "w-1", Address: "localhost", Port: 18081}); err != nil {
+		t.Fatalf("register worker: %v", err)
+	}
+
+	// Create first job and start it
+	first, err := jm.CreateJob(JobRequest{Targets: []JobTarget{{RedisURL: "redis://localhost:6379", WorkerCount: 1}}})
+	if err != nil {
+		t.Fatalf("create first job: %v", err)
+	}
+	if err := jm.StartJob(first.ID); err != nil {
+		t.Fatalf("start first job: %v", err)
+	}
+
+	// Attempt to create a second job while the first is running
+	_, err = jm.CreateJob(JobRequest{Targets: []JobTarget{{RedisURL: "redis://localhost:6379", WorkerCount: 1}}})
+	if err == nil {
+		t.Fatal("expected error when creating job while another is running")
+	}
+	if !errors.Is(err, ErrJobAlreadyRunning) {
+		t.Fatalf("expected ErrJobAlreadyRunning, got %v", err)
+	}
+
+	// Ensure no extra jobs were added
+	if got := len(jm.ListJobs()); got != 1 {
+		t.Fatalf("expected exactly 1 job in manager, got %d", got)
+	}
+}
+
 func TestSendJobToWorker_ForwardsTestOverrides(t *testing.T) {
 	registry := NewRegistry()
 	cfg := &config.Config{
@@ -657,6 +693,54 @@ func TestSendJobToWorker_ForwardsTestOverrides(t *testing.T) {
 		// It's fine if present, but not necessary for correctness. No assertion.
 	default:
 		t.Fatal("did not receive worker start payload")
+	}
+}
+
+func TestStartJobHandler_Returns409WhenAnotherJobRunning(t *testing.T) {
+	cfg := &config.Config{Controller: config.LoadControllerConfig()}
+	c := NewController(cfg)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/workers/register", c.RegisterWorkerHandler)
+	mux.HandleFunc("/job/start", c.StartJobHandler)
+
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	// Register two workers to allow jobs to start
+	for i := 0; i < 2; i++ {
+		payload := map[string]any{"workerId": fmt.Sprintf("w-%d", i+1), "address": "localhost", "port": 19080 + i}
+		b, _ := json.Marshal(payload)
+		resp, err := http.Post(srv.URL+"/workers/register", "application/json", bytes.NewBuffer(b))
+		if err != nil {
+			t.Fatalf("register worker: %v", err)
+		}
+		resp.Body.Close()
+		if resp.StatusCode != http.StatusCreated {
+			t.Fatalf("unexpected register status: %d", resp.StatusCode)
+		}
+	}
+
+	// Start first job
+	startPayload := map[string]any{"targets": []map[string]any{{"redisUrl": "redis://localhost:6379", "workerCount": 1}}}
+	sb, _ := json.Marshal(startPayload)
+	resp, err := http.Post(srv.URL+"/job/start", "application/json", bytes.NewBuffer(sb))
+	if err != nil {
+		t.Fatalf("start first job: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("unexpected first start status: %d", resp.StatusCode)
+	}
+
+	// Attempt to start a second job while the first is running
+	resp, err = http.Post(srv.URL+"/job/start", "application/json", bytes.NewBuffer(sb))
+	if err != nil {
+		t.Fatalf("start second job: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusConflict {
+		t.Fatalf("expected 409 Conflict, got %d", resp.StatusCode)
 	}
 }
 


### PR DESCRIPTION
This PR implements a single job execution limit per controller, preventing multiple jobs from running simultaneously. The change adds validation logic to reject job creation and start requests when another job is already running, returning a 409 Conflict status code.

- Adds validation to prevent concurrent job execution in the job manager
- Introduces proper error handling with a dedicated error type for job conflicts  
- Updates HTTP handlers to return 409 Conflict status when attempting to start multiple jobs
