### PR TITLE
compose: adjust example

### DIFF
--- a/compose-example.yaml
+++ b/compose-example.yaml
@@ -12,26 +12,41 @@ x-bench_base: &bench_base
     - valkey
 
 services:
-  bench_redis8:
+  controller:
     <<: *bench_base
+    command: ["--mode=controller", "--port=8081"]
     ports:
-      - "8081:8080"
-    environment:
-      - REDIS_URL=redis://redis8:6379
+      - "8081:8081"
 
-  bench_redis7:
+  worker_redis8_1:
     <<: *bench_base
-    ports:
-      - "8083:8080"
-    environment:
-      - REDIS_URL=redis://redis7:6379
+    command: ["--mode=worker", "--port=8080", "--controller=http://controller:8081", "--bind-address=worker_redis8_1"]
+    depends_on:
+      - prometheus
+      - redis8
+      - redis7
+      - valkey
+      - controller
 
-  bench_valkey:
+  worker_redis7_1:
     <<: *bench_base
-    ports:
-      - "8082:8080"
-    environment:
-      - REDIS_URL=redis://valkey:6379
+    command: ["--mode=worker", "--port=8080", "--controller=http://controller:8081", "--bind-address=worker_redis7_1"]
+    depends_on:
+      - prometheus
+      - redis8
+      - redis7
+      - valkey
+      - controller
+
+  worker_valkey_1:
+    <<: *bench_base
+    command: ["--mode=worker", "--port=8080", "--controller=http://controller:8081", "--bind-address=worker_valkey_1"]
+    depends_on:
+      - prometheus
+      - redis8
+      - redis7
+      - valkey
+      - controller
 
   redis8:
     image: redis:8.0
@@ -114,5 +129,21 @@ services:
       - ./grafana/dashboards:/var/lib/grafana/dashboards
       - ./grafana:/etc/grafana/provisioning/datasources
       - ./grafana/dashboard.yaml:/etc/grafana/provisioning/dashboards/main.yaml
+  job_init:
+    image: alpine:3.20
+    container_name: job_init
+    depends_on:
+      - controller
+      - worker_redis8_1
+      - worker_redis7_1
+      - worker_valkey_1
+    volumes:
+      - ./redbench/scripts/compose-start-job.sh:/compose-start-job.sh:ro
+    environment:
+      - CONTROLLER_URL=http://controller:8081
+      - EXPECTED_WORKERS=3
+      - MAX_WAIT_SECS=180
+      - SLEEP_SECS=2
+    entrypoint: ["/bin/sh", "-c", "apk add --no-cache curl >/dev/null 2>&1 && /bin/sh /compose-start-job.sh"]
 volumes:
   prom_data:

--- a/compose-example.yaml
+++ b/compose-example.yaml
@@ -132,6 +132,7 @@ services:
   job_init:
     image: alpine:3.20
     container_name: job_init
+    profiles: ["autostart"]
     depends_on:
       - controller
       - worker_redis8_1

--- a/compose-minimal-controller-workers.yaml
+++ b/compose-minimal-controller-workers.yaml
@@ -1,0 +1,72 @@
+x-redbench_base: &redbench_base
+  build:
+    context: ./redbench
+    dockerfile: Dockerfile
+  volumes:
+    - ./redbench/config.yaml:/config.yaml
+  restart: no
+
+services:
+  controller:
+    <<: *redbench_base
+    command: ["--mode=controller", "--port=8081"]
+    ports:
+      - "8081:8081"
+
+  worker_1:
+    <<: *redbench_base
+    command: ["--mode=worker", "--port=8080", "--controller=http://controller:8081", "--bind-address=worker_1"]
+    depends_on:
+      - controller
+
+  worker_2:
+    <<: *redbench_base
+    command: ["--mode=worker", "--port=8080", "--controller=http://controller:8081", "--bind-address=worker_2"]
+    depends_on:
+      - controller
+
+  worker_3:
+    <<: *redbench_base
+    command: ["--mode=worker", "--port=8080", "--controller=http://controller:8081", "--bind-address=worker_3"]
+    depends_on:
+      - controller
+
+  worker_4:
+    <<: *redbench_base
+    command: ["--mode=worker", "--port=8080", "--controller=http://controller:8081", "--bind-address=worker_4"]
+    depends_on:
+      - controller
+
+  prometheus:
+    image: prom/prometheus
+    container_name: prometheus-min
+    command:
+      - '--config.file=/etc/prometheus/prometheus.yml'
+    ports:
+      - 9090:9090
+    restart: unless-stopped
+    volumes:
+      - ./prometheus/prometheus-minimal.yml:/etc/prometheus/prometheus.yml
+      - prom_data_min:/prometheus
+
+  grafana:
+    image: grafana/grafana
+    container_name: grafana-min
+    ports:
+      - 3000:3000
+    restart: unless-stopped
+    environment:
+      - GF_DASHBOARDS_JSON_ENABLED=true
+      - GF_PATHS_PROVISIONING=/etc/grafana/provisioning
+      - GF_PATHS_DASHBOARDS=/var/lib/grafana/dashboards
+      - GF_SECURITY_ADMIN_USER=admin
+      - GF_SECURITY_ADMIN_PASSWORD=grafana
+    volumes:
+      - ./grafana/dashboards:/var/lib/grafana/dashboards
+      - ./grafana:/etc/grafana/provisioning/datasources
+      - ./grafana/dashboard.yaml:/etc/grafana/provisioning/dashboards/main.yaml
+
+volumes:
+  prom_data_min:
+
+

--- a/prometheus/prometheus-minimal.yml
+++ b/prometheus/prometheus-minimal.yml
@@ -1,0 +1,30 @@
+global:
+  scrape_interval: 10s
+  scrape_timeout: 5s
+  evaluation_interval: 10s
+
+scrape_configs:
+- job_name: redbench_workers
+  honor_timestamps: true
+  scrape_interval: 10s
+  scrape_timeout: 5s
+  metrics_path: /metrics
+  scheme: http
+  static_configs:
+  - targets:
+    - worker_1:8080
+    - worker_2:8080
+    - worker_3:8080
+    - worker_4:8080
+
+- job_name: redbench_controller
+  honor_timestamps: true
+  scrape_interval: 10s
+  scrape_timeout: 5s
+  metrics_path: /metrics
+  scheme: http
+  static_configs:
+  - targets:
+    - controller:8081
+
+

--- a/prometheus/prometheus.yml
+++ b/prometheus/prometheus.yml
@@ -3,7 +3,7 @@ global:
   scrape_timeout: 5s
   evaluation_interval: 10s
 scrape_configs:
-- job_name: redbench
+- job_name: redbench_workers
   honor_timestamps: true
   scrape_interval: 10s
   scrape_timeout: 5s
@@ -11,9 +11,9 @@ scrape_configs:
   scheme: http
   static_configs:
   - targets:
-    - bench_redis8:8080
-    - bench_redis7:8080
-    - bench_valkey:8080
+    - worker_redis8_1:8080
+    - worker_redis7_1:8080
+    - worker_valkey_1:8080
 
 - job_name: redis_exporters
   honor_timestamps: true

--- a/redbench/CONTROLLER_USAGE.md
+++ b/redbench/CONTROLLER_USAGE.md
@@ -197,7 +197,12 @@ The repository provides `compose-example.yaml` that starts:
 - three Redis servers (`redis8`, `redis7`, `valkey`)
 - one worker per Redis (workers are not exposed; Prometheus scrapes them internally)
 
-After `docker compose up`, start a coordinated job via the controller:
+After `docker compose up`, open the UI and optionally import configuration:
+
+- UI: http://localhost:8081/ui/
+- Configuration import endpoint (used by the UI): `/api/v1/runtime-config`
+
+To start a coordinated job via the API:
 
 ```bash
 curl -X POST http://localhost:8081/job/start \
@@ -218,6 +223,16 @@ curl http://localhost:8081/job/status
 ```
 
 Prometheus scrapes the workers and the controller; Grafana dashboards are pre-provisioned to visualize metrics.
+
+## Optional: Auto-start job on boot
+
+The example compose file includes an optional one-shot `job_init` service behind the `autostart` profile. To enable it:
+
+```bash
+docker compose -f compose-example.yaml --profile autostart up --build
+```
+
+Without the profile, the stack starts idle and you can configure and launch jobs from the UI.
 
 ## Legacy Modes (unchanged)
 

--- a/redbench/CONTROLLER_USAGE.md
+++ b/redbench/CONTROLLER_USAGE.md
@@ -189,6 +189,36 @@ Use the provided demo script to test the controller-worker setup:
 ./scripts/test-controller-worker.sh
 ```
 
+## Docker Compose Usage
+
+The repository provides `compose-example.yaml` that starts:
+
+- `controller` on port 8081 (exposed to host)
+- three Redis servers (`redis8`, `redis7`, `valkey`)
+- one worker per Redis (workers are not exposed; Prometheus scrapes them internally)
+
+After `docker compose up`, start a coordinated job via the controller:
+
+```bash
+curl -X POST http://localhost:8081/job/start \
+  -H "Content-Type: application/json" \
+  -d '{
+    "targets": [
+      {"redisUrl": "redis://redis8:6379", "workerCount": 1},
+      {"redisUrl": "redis://redis7:6379", "workerCount": 1},
+      {"redisUrl": "redis://valkey:6379", "workerCount": 1}
+    ],
+    "config": {
+      "test": { "minClients": 1, "maxClients": 50, "stageIntervalMs": 1000, "requestDelayMs": 100, "keySize": 10, "valueSize": 100 }
+    }
+  }'
+
+curl http://localhost:8081/workers
+curl http://localhost:8081/job/status
+```
+
+Prometheus scrapes the workers and the controller; Grafana dashboards are pre-provisioned to visualize metrics.
+
 ## Legacy Modes (unchanged)
 
 ```bash

--- a/redbench/README.md
+++ b/redbench/README.md
@@ -6,6 +6,7 @@ Redis benchmarking tool that measures performance and provides Prometheus metric
 
 - **CLI Mode**: Traditional one-shot benchmarking
 - **Service Mode**: HTTP API for remote control and multiple benchmarks
+- **Controller/Worker Mode**: Centralized orchestration across workers with optional UI
 - **Prometheus Metrics**: Real-time performance monitoring
 - **TLS Support**: Secure connections with certificate validation
 - **Cluster Support**: Redis cluster and single-instance modes
@@ -46,6 +47,35 @@ curl http://localhost:8080/status | jq
 
 # Stop benchmark
 curl -X DELETE http://localhost:8080/stop | jq
+```
+
+### Controller/Worker Mode (Docker Compose)
+
+```bash
+# 1) Start the stack (controller, workers, Redis, Prometheus, Grafana)
+docker compose -f compose-example.yaml up --build
+
+# 2) Start a coordinated job via the controller (port 8081)
+curl -X POST http://localhost:8081/job/start \
+  -H "Content-Type: application/json" \
+  -d '{
+    "targets": [
+      {"redisUrl": "redis://redis8:6379", "workerCount": 1},
+      {"redisUrl": "redis://redis7:6379", "workerCount": 1},
+      {"redisUrl": "redis://valkey:6379", "workerCount": 1}
+    ],
+    "config": {
+      "test": { "minClients": 1, "maxClients": 50, "stageIntervalMs": 1000, "requestDelayMs": 100, "keySize": 10, "valueSize": 100 }
+    }
+  }'
+
+# 3) Inspect controller and workers
+curl http://localhost:8081/health
+curl http://localhost:8081/workers
+curl http://localhost:8081/job/status
+
+# UI (served by controller)
+# http://localhost:8081/ui/
 ```
 
 ## Project Structure
@@ -218,11 +248,17 @@ Redis connection requires either URL or ClusterURL to be specified
 
 ### Prometheus Metrics
 
-Metrics are available at `http://localhost:8080/metrics` (unified port for both CLI and service modes):
+Metrics are exposed on each running server under `/metrics`:
+
+- In CLI and service modes, the default port is 8080 (configurable via `API_PORT`).
+- In controller/worker mode (Compose), the controller exposes `http://localhost:8081/metrics`; workers are scraped inside the Compose network by Prometheus.
 
 ```bash
-# View all redbench metrics
+# Example (service/CLI mode):
 curl http://localhost:8080/metrics | grep redbench
+
+# Example (controller mode):
+curl http://localhost:8081/metrics | grep redbench
 ```
 
 Key metrics:
@@ -291,7 +327,7 @@ go tool cover -html=coverage.out
 
 ### Docker Compose Setup
 
-See `compose-example.yaml` for a complete setup with Redis, Grafana, and Prometheus.
+See `compose-example.yaml` for a complete controller/worker setup with Redis, Prometheus, and Grafana.
 
 ### CI/CD
 

--- a/redbench/README.md
+++ b/redbench/README.md
@@ -76,6 +76,9 @@ curl http://localhost:8081/job/status
 
 # UI (served by controller)
 # http://localhost:8081/ui/
+
+# Tip: optional autostart profile to kick off a job at boot
+# docker compose -f compose-example.yaml --profile autostart up --build
 ```
 
 ## Project Structure

--- a/redbench/scripts/compose-start-job.sh
+++ b/redbench/scripts/compose-start-job.sh
@@ -1,0 +1,78 @@
+#!/bin/sh
+set -eu
+
+log() { echo "job_init: $*"; }
+
+CONTROLLER_URL="${CONTROLLER_URL:-http://controller:8081}"
+EXPECTED_WORKERS="${EXPECTED_WORKERS:-3}"
+MAX_WAIT_SECS="${MAX_WAIT_SECS:-120}"
+SLEEP_SECS="${SLEEP_SECS:-2}"
+
+start_ts=$(date +%s)
+
+log "waiting for controller at $CONTROLLER_URL"
+while :; do
+  code=$(curl -s -o /dev/null -w "%{http_code}" "$CONTROLLER_URL/health" || true)
+  if [ "$code" = "200" ]; then
+    break
+  fi
+  now=$(date +%s)
+  if [ $((now - start_ts)) -ge "$MAX_WAIT_SECS" ]; then
+    log "timeout waiting for controller health"
+    exit 1
+  fi
+  sleep "$SLEEP_SECS"
+done
+
+log "controller is healthy; waiting for $EXPECTED_WORKERS workers to register"
+while :; do
+  resp=$(curl -s "$CONTROLLER_URL/workers" || true)
+  # Extract numeric value of "total" using sed; fallback to 0 if parse fails
+  total=$(echo "$resp" | tr -d '\n' | sed -e 's/.*"total"[[:space:]]*:[[:space:]]*//' -e 's/[^0-9].*//' )
+  case "$total" in
+    ('' ) total=0 ;;
+  esac
+  if [ "$total" -ge "$EXPECTED_WORKERS" ]; then
+    break
+  fi
+  now=$(date +%s)
+  if [ $((now - start_ts)) -ge "$MAX_WAIT_SECS" ]; then
+    log "timeout waiting for workers (got ${total}/$EXPECTED_WORKERS)"
+    exit 1
+  fi
+  sleep "$SLEEP_SECS"
+done
+
+log "workers ready; starting coordinated job"
+payload='{
+  "targets": [
+    {"redisUrl": "redis://redis8:6379", "workerCount": 1},
+    {"redisUrl": "redis://redis7:6379", "workerCount": 1},
+    {"redisUrl": "redis://valkey:6379", "workerCount": 1}
+  ],
+  "config": {
+    "test": {
+      "minClients": 1,
+      "maxClients": 50,
+      "stageIntervalMs": 1000,
+      "requestDelayMs": 100,
+      "keySize": 10,
+      "valueSize": 100
+    }
+  }
+}'
+
+http_code=$(curl -s -o /tmp/job_resp.json -w "%{http_code}" \
+  -X POST "$CONTROLLER_URL/job/start" \
+  -H "Content-Type: application/json" \
+  -d "$payload" || true)
+
+if [ "$http_code" = "201" ] || [ "$http_code" = "409" ]; then
+  log "job request completed with HTTP $http_code"
+  cat /tmp/job_resp.json || true
+  exit 0
+fi
+
+log "job request failed with HTTP $http_code"
+cat /tmp/job_resp.json || true
+exit 1


### PR DESCRIPTION
This PR adjusts the Docker Compose example to use the new controller/worker mode instead of the previous direct benchmark approach. The changes implement a centralized orchestration pattern where a single controller coordinates multiple workers across different Redis instances.

Key changes:
- Replaced direct benchmark services with a controller/worker architecture
- Added automated job initialization script for the compose environment
- Updated documentation to reflect the new controller/worker mode usage