### PR TITLE
redbench: add hset_hget

### DIFF
--- a/redbench/internal/benchmark/benchmark.go
+++ b/redbench/internal/benchmark/benchmark.go
@@ -138,6 +138,39 @@ func (r *Runner) Run(ctx context.Context) error {
 							slog.Error("GetBatchData failed", "err", err)
 						}
 					}
+				case config.WorkloadHSetHGet:
+					tag := ""
+					if r.config.Test.SameSlotPerClient {
+						tag = utils.NewHashSlotTag()
+					}
+					// HSET with batchSize fields in a single hash key
+					opCtx, cancel := context.WithTimeout(ctx, opTimeout)
+					batchSize := r.config.Test.BatchSize
+					if batchSize <= 0 {
+						batchSize = defaultBatchSize
+					}
+					hashKey, fields, err := r.redisOps.SaveRandomHashData(opCtx, r.config.Redis.Expiration, r.config.Test.KeySize, r.config.Test.ValueSize, batchSize, tag)
+					cancel()
+					if err != nil {
+						if ctx.Err() == nil {
+							slog.Error("SaveRandomHashData failed", "err", err)
+						}
+					}
+
+					if ctx.Err() != nil {
+						<-clients
+						return
+					}
+
+					// HGET/HMGET
+					opCtx2, cancel2 := context.WithTimeout(ctx, opTimeout)
+					err = r.redisOps.GetHashData(opCtx2, hashKey, fields)
+					cancel2()
+					if err != nil {
+						if ctx.Err() == nil {
+							slog.Error("GetHashData failed", "err", err)
+						}
+					}
 				default:
 					opCtx, cancel := context.WithTimeout(ctx, opTimeout)
 					key, err := r.redisOps.SaveRandomData(opCtx, r.config.Redis.Expiration, r.config.Test.KeySize, r.config.Test.ValueSize)

--- a/redbench/internal/benchmark/benchmark_test.go
+++ b/redbench/internal/benchmark/benchmark_test.go
@@ -38,6 +38,16 @@ func (m *MockRedisClient) MGet(ctx context.Context, keys []string) error {
 	return args.Error(0)
 }
 
+func (m *MockRedisClient) HSet(ctx context.Context, key string, fieldValues map[string]string) error {
+	args := m.Called(ctx, key, fieldValues)
+	return args.Error(0)
+}
+
+func (m *MockRedisClient) HMGet(ctx context.Context, key string, fields []string) error {
+	args := m.Called(ctx, key, fields)
+	return args.Error(0)
+}
+
 func (m *MockRedisClient) ExpireMany(ctx context.Context, keys []string, expiration int32) error {
 	args := m.Called(ctx, keys, expiration)
 	return args.Error(0)

--- a/redbench/internal/config/config.go
+++ b/redbench/internal/config/config.go
@@ -19,6 +19,7 @@ import (
 const (
 	WorkloadSetGet   = "set_get"
 	WorkloadMSetMGet = "mset_mget"
+	WorkloadHSetHGet = "hset_hget"
 )
 
 // IsBatchWorkload reports whether the given workload uses batch operations.
@@ -26,6 +27,8 @@ const (
 func IsBatchWorkload(workload string) bool {
 	switch workload {
 	case WorkloadMSetMGet:
+		return true
+	case WorkloadHSetHGet:
 		return true
 	default:
 		return false

--- a/redbench/internal/metrics/metrics.go
+++ b/redbench/internal/metrics/metrics.go
@@ -22,11 +22,15 @@ type Metrics struct {
 	durationGet         prometheus.Observer
 	durationMSet        prometheus.Observer
 	durationMGet        prometheus.Observer
+	durationHSet        prometheus.Observer
+	durationHGet        prometheus.Observer
 	durationExpire      prometheus.Observer
 	requestFailedSet    prometheus.Counter
 	requestFailedGet    prometheus.Counter
 	requestFailedMSet   prometheus.Counter
 	requestFailedMGet   prometheus.Counter
+	requestFailedHSet   prometheus.Counter
+	requestFailedHGet   prometheus.Counter
 	requestFailedExpire prometheus.Counter
 
 	redisPoolTotalConns prometheus.Gauge
@@ -191,11 +195,15 @@ func New(reg prometheus.Registerer, target string) *Metrics {
 	m.durationGet = m.duration.WithLabelValues("get", "redis", target)
 	m.durationMSet = m.duration.WithLabelValues("mset", "redis", target)
 	m.durationMGet = m.duration.WithLabelValues("mget", "redis", target)
+	m.durationHSet = m.duration.WithLabelValues("hset", "redis", target)
+	m.durationHGet = m.duration.WithLabelValues("hget", "redis", target)
 	m.durationExpire = m.duration.WithLabelValues("expire", "redis", target)
 	m.requestFailedSet = m.requestFailed.WithLabelValues("set", "redis", target)
 	m.requestFailedGet = m.requestFailed.WithLabelValues("get", "redis", target)
 	m.requestFailedMSet = m.requestFailed.WithLabelValues("mset", "redis", target)
 	m.requestFailedMGet = m.requestFailed.WithLabelValues("mget", "redis", target)
+	m.requestFailedHSet = m.requestFailed.WithLabelValues("hset", "redis", target)
+	m.requestFailedHGet = m.requestFailed.WithLabelValues("hget", "redis", target)
 	m.requestFailedExpire = m.requestFailed.WithLabelValues("expire", "redis", target)
 
 	return m
@@ -236,6 +244,16 @@ func (m *Metrics) ObserveMGetDuration(duration float64) {
 	m.durationMGet.Observe(duration)
 }
 
+// ObserveHSetDuration records the duration of an HSET operation.
+func (m *Metrics) ObserveHSetDuration(duration float64) {
+	m.durationHSet.Observe(duration)
+}
+
+// ObserveHGetDuration records the duration of an HGET operation.
+func (m *Metrics) ObserveHGetDuration(duration float64) {
+	m.durationHGet.Observe(duration)
+}
+
 // ObserveExpireDuration records the duration of an EXPIRE operation (batched via pipeline).
 func (m *Metrics) ObserveExpireDuration(duration float64) {
 	m.durationExpire.Observe(duration)
@@ -259,6 +277,16 @@ func (m *Metrics) IncrementMSetFailures() {
 // IncrementMGetFailures increments the counter for failed MGET operations.
 func (m *Metrics) IncrementMGetFailures() {
 	m.requestFailedMGet.Inc()
+}
+
+// IncrementHSetFailures increments the counter for failed HSET operations.
+func (m *Metrics) IncrementHSetFailures() {
+	m.requestFailedHSet.Inc()
+}
+
+// IncrementHGetFailures increments the counter for failed HGET operations.
+func (m *Metrics) IncrementHGetFailures() {
+	m.requestFailedHGet.Inc()
 }
 
 // IncrementExpireFailures increments the counter for failed EXPIRE operations.

--- a/redbench/internal/redis/client.go
+++ b/redbench/internal/redis/client.go
@@ -17,6 +17,8 @@ type Client interface {
 	Get(ctx context.Context, key string) (string, error)
 	MSet(ctx context.Context, kv map[string]string) error
 	MGet(ctx context.Context, keys []string) error
+	HSet(ctx context.Context, key string, fieldValues map[string]string) error
+	HMGet(ctx context.Context, key string, fields []string) error
 	ExpireMany(ctx context.Context, keys []string, expiration int32) error
 	PoolStats() *redis.PoolStats
 	Close() error
@@ -147,6 +149,27 @@ func (r *RedisClient) MGet(ctx context.Context, keys []string) error {
 		return nil
 	}
 	_, err := r.client.MGet(ctx, keys...).Result()
+	return err
+}
+
+// HSet sets multiple field/value pairs on a hash key.
+func (r *RedisClient) HSet(ctx context.Context, key string, fieldValues map[string]string) error {
+	if len(fieldValues) == 0 {
+		return nil
+	}
+	args := make([]any, 0, len(fieldValues)*2)
+	for f, v := range fieldValues {
+		args = append(args, f, v)
+	}
+	return r.client.HSet(ctx, key, args...).Err()
+}
+
+// HMGet fetches multiple fields from a hash key.
+func (r *RedisClient) HMGet(ctx context.Context, key string, fields []string) error {
+	if len(fields) == 0 {
+		return nil
+	}
+	_, err := r.client.HMGet(ctx, key, fields...).Result()
 	return err
 }
 

--- a/redbench/internal/redis/operations.go
+++ b/redbench/internal/redis/operations.go
@@ -14,11 +14,15 @@ type MetricsRecorder interface {
 	ObserveGetDuration(duration float64)
 	ObserveMSetDuration(duration float64)
 	ObserveMGetDuration(duration float64)
+	ObserveHSetDuration(duration float64)
+	ObserveHGetDuration(duration float64)
 	ObserveExpireDuration(duration float64)
 	IncrementSetFailures()
 	IncrementGetFailures()
 	IncrementMSetFailures()
 	IncrementMGetFailures()
+	IncrementHSetFailures()
+	IncrementHGetFailures()
 	IncrementExpireFailures()
 }
 
@@ -145,5 +149,57 @@ func (o *Operations) GetBatchData(ctx context.Context, keys []string) error {
 	if o.debug {
 		fmt.Printf("mget fetched %d items\n", len(keys))
 	}
+	return nil
+}
+
+// SaveRandomHashData creates one hash key with batchSize fields using HSET and applies expiration.
+// Returns the hash key and list of field names used.
+func (o *Operations) SaveRandomHashData(ctx context.Context, expiration int32, keySize, fieldValueSize, batchSize int, sameSlotTag string) (string, []string, error) {
+	if batchSize <= 0 {
+		return "", nil, fmt.Errorf("batch size must be > 0")
+	}
+	var key string
+	if sameSlotTag != "" {
+		key = utils.ComposeTaggedKeyWithCounter(sameSlotTag, keySize, defaultTaggedSuffixLen, 0)
+	} else {
+		key = utils.RandomString(keySize)
+	}
+
+	fields := make([]string, 0, batchSize)
+	fv := make(map[string]string, batchSize)
+	for i := 0; i < batchSize; i++ {
+		field := "f" + utils.Base36Padded(i, 1)
+		fields = append(fields, field)
+		fv[field] = utils.RandomString(fieldValueSize)
+	}
+
+	start := time.Now()
+	if err := o.client.HSet(ctx, key, fv); err != nil {
+		o.metrics.IncrementHSetFailures()
+		return "", nil, fmt.Errorf("failed to hset fields in Redis: %w", err)
+	}
+	o.metrics.ObserveHSetDuration(time.Since(start).Seconds())
+
+	if expiration > 0 {
+		if err := o.client.ExpireMany(ctx, []string{key}, expiration); err != nil {
+			o.metrics.IncrementExpireFailures()
+			return "", nil, fmt.Errorf("failed to expire hash key: %w", err)
+		}
+		// We do not observe separate expire duration for single-key path to keep parity
+	}
+	return key, fields, nil
+}
+
+// GetHashData fetches multiple fields from a hash key using HMGET.
+func (o *Operations) GetHashData(ctx context.Context, key string, fields []string) error {
+	if len(fields) == 0 {
+		return nil
+	}
+	start := time.Now()
+	if err := o.client.HMGet(ctx, key, fields); err != nil {
+		o.metrics.IncrementHGetFailures()
+		return fmt.Errorf("failed to hmget fields from Redis: %w", err)
+	}
+	o.metrics.ObserveHGetDuration(time.Since(start).Seconds())
 	return nil
 }

--- a/redbench/internal/redis/operations_bench_test.go
+++ b/redbench/internal/redis/operations_bench_test.go
@@ -11,10 +11,12 @@ import (
 
 type noopClient struct{}
 
-func (n *noopClient) Set(ctx context.Context, k, v string, exp int32) error { return nil }
-func (n *noopClient) Get(ctx context.Context, k string) (string, error)     { return "", nil }
-func (n *noopClient) MSet(ctx context.Context, kv map[string]string) error  { return nil }
-func (n *noopClient) MGet(ctx context.Context, keys []string) error         { return nil }
+func (n *noopClient) Set(ctx context.Context, k, v string, exp int32) error            { return nil }
+func (n *noopClient) Get(ctx context.Context, k string) (string, error)                { return "", nil }
+func (n *noopClient) MSet(ctx context.Context, kv map[string]string) error             { return nil }
+func (n *noopClient) MGet(ctx context.Context, keys []string) error                    { return nil }
+func (n *noopClient) HSet(ctx context.Context, key string, fv map[string]string) error { return nil }
+func (n *noopClient) HMGet(ctx context.Context, key string, fields []string) error     { return nil }
 func (n *noopClient) ExpireMany(ctx context.Context, keys []string, exp int32) error {
 	return nil
 }

--- a/redbench/internal/redis/operations_test.go
+++ b/redbench/internal/redis/operations_test.go
@@ -35,6 +35,16 @@ func (m *MockClient) MGet(ctx context.Context, keys []string) error {
 	return args.Error(0)
 }
 
+func (m *MockClient) HSet(ctx context.Context, key string, fieldValues map[string]string) error {
+	args := m.Called(ctx, key, fieldValues)
+	return args.Error(0)
+}
+
+func (m *MockClient) HMGet(ctx context.Context, key string, fields []string) error {
+	args := m.Called(ctx, key, fields)
+	return args.Error(0)
+}
+
 func (m *MockClient) ExpireMany(ctx context.Context, keys []string, expiration int32) error {
 	args := m.Called(ctx, keys, expiration)
 	return args.Error(0)
@@ -71,6 +81,9 @@ func (m *MockMetrics) ObserveMGetDuration(duration float64) {
 	m.Called(duration)
 }
 
+func (m *MockMetrics) ObserveHSetDuration(duration float64) { m.Called(duration) }
+func (m *MockMetrics) ObserveHGetDuration(duration float64) { m.Called(duration) }
+
 func (m *MockMetrics) ObserveExpireDuration(duration float64) {
 	m.Called(duration)
 }
@@ -90,6 +103,9 @@ func (m *MockMetrics) IncrementMSetFailures() {
 func (m *MockMetrics) IncrementMGetFailures() {
 	m.Called()
 }
+
+func (m *MockMetrics) IncrementHSetFailures() { m.Called() }
+func (m *MockMetrics) IncrementHGetFailures() { m.Called() }
 
 func (m *MockMetrics) IncrementExpireFailures() {
 	m.Called()


### PR DESCRIPTION
This PR adds support for Redis hash operations (HSET/HGET/HMGET) to the redbench benchmarking tool. The implementation includes a new workload type for testing hash-based operations alongside the existing SET/GET and MSET/MGET workloads.

- Added Redis hash operations (HSet/HMGet) to the client interface and implementation
- Implemented hash-specific metrics tracking for duration and failure counting
- Added new workload type "hset_hget"
- Added new workload type "hset_hmget"