### PR TITLE
Feature/fix hash batch

### DIFF
--- a/redbench/internal/benchmark/benchmark.go
+++ b/redbench/internal/benchmark/benchmark.go
@@ -303,7 +303,7 @@ func (r *Runner) Run(ctx context.Context) error {
 							}
 							opCtx4, cancel4 := context.WithTimeout(ctx, opTimeout)
 							dest := "z:lb:" + tag + ":union"
-							if err := r.redisOps.ZUnionWithinTag(opCtx4, dest, sources, topK); err != nil {
+							if err := r.redisOps.ZUnionWithinTag(opCtx4, dest, sources, topK, r.config.Redis.Expiration); err != nil {
 								if ctx.Err() == nil {
 									slog.Error("ZUnionWithinTag failed", "err", err)
 								}

--- a/redbench/internal/benchmark/benchmark.go
+++ b/redbench/internal/benchmark/benchmark.go
@@ -202,7 +202,15 @@ func (r *Runner) Run(ctx context.Context) error {
 					if perTag > 1 {
 						lbIdx = int(time.Now().UnixNano() % int64(perTag))
 					}
-					zkey := "z:lb:" + tag + ":" + utils.Base36Padded(lbIdx, 1)
+					// Use dynamic width so index formatting scales with number of leaderboards
+					zIdxWidth := 1
+					if perTag > 1 {
+						w := len(utils.Base36Padded(perTag-1, 1))
+						if w > zIdxWidth {
+							zIdxWidth = w
+						}
+					}
+					zkey := "z:lb:" + tag + ":" + utils.Base36Padded(lbIdx, zIdxWidth)
 
 					// ZADD a batch of members
 					opCtx, cancel := context.WithTimeout(ctx, opTimeout)
@@ -282,8 +290,16 @@ func (r *Runner) Run(ctx context.Context) error {
 								fanIn = perTag
 							}
 							sources := make([]string, 0, fanIn)
+							// Match dynamic width used for zkey above
+							unionWidth := 1
+							if perTag > 1 {
+								w := len(utils.Base36Padded(perTag-1, 1))
+								if w > unionWidth {
+									unionWidth = w
+								}
+							}
 							for i := 0; i < fanIn; i++ {
-								sources = append(sources, "z:lb:"+tag+":"+utils.Base36Padded(i, 1))
+								sources = append(sources, "z:lb:"+tag+":"+utils.Base36Padded(i, unionWidth))
 							}
 							opCtx4, cancel4 := context.WithTimeout(ctx, opTimeout)
 							dest := "z:lb:" + tag + ":union"

--- a/redbench/internal/benchmark/benchmark.go
+++ b/redbench/internal/benchmark/benchmark.go
@@ -203,13 +203,7 @@ func (r *Runner) Run(ctx context.Context) error {
 						lbIdx = int(time.Now().UnixNano() % int64(perTag))
 					}
 					// Use dynamic width so index formatting scales with number of leaderboards
-					zIdxWidth := 1
-					if perTag > 1 {
-						w := len(utils.Base36Padded(perTag-1, 1))
-						if w > zIdxWidth {
-							zIdxWidth = w
-						}
-					}
+					zIdxWidth := utils.Base36WidthForMax(perTag - 1)
 					zkey := "z:lb:" + tag + ":" + utils.Base36Padded(lbIdx, zIdxWidth)
 
 					// ZADD a batch of members
@@ -291,13 +285,7 @@ func (r *Runner) Run(ctx context.Context) error {
 							}
 							sources := make([]string, 0, fanIn)
 							// Match dynamic width used for zkey above
-							unionWidth := 1
-							if perTag > 1 {
-								w := len(utils.Base36Padded(perTag-1, 1))
-								if w > unionWidth {
-									unionWidth = w
-								}
-							}
+							unionWidth := utils.Base36WidthForMax(perTag - 1)
 							for i := 0; i < fanIn; i++ {
 								sources = append(sources, "z:lb:"+tag+":"+utils.Base36Padded(i, unionWidth))
 							}

--- a/redbench/internal/redis/operations.go
+++ b/redbench/internal/redis/operations.go
@@ -297,7 +297,7 @@ func (o *Operations) ZTrimToTopK(ctx context.Context, key string, topK int64) er
 }
 
 // ZUnionWithinTag unions multiple keys into a destination key within same slot tag and trims.
-func (o *Operations) ZUnionWithinTag(ctx context.Context, dest string, sources []string, trimTopK int64) error {
+func (o *Operations) ZUnionWithinTag(ctx context.Context, dest string, sources []string, trimTopK int64, expiration int32) error {
 	if len(sources) == 0 || dest == "" {
 		return nil
 	}
@@ -310,6 +310,12 @@ func (o *Operations) ZUnionWithinTag(ctx context.Context, dest string, sources [
 	if trimTopK > 0 {
 		if err := o.ZTrimToTopK(ctx, dest, trimTopK); err != nil {
 			return err
+		}
+	}
+	if expiration > 0 {
+		if err := o.client.ExpireMany(ctx, []string{dest}, expiration); err != nil {
+			o.metrics.IncrementExpireFailures()
+			return fmt.Errorf("failed to expire zset union dest: %w", err)
 		}
 	}
 	return nil

--- a/redbench/internal/redis/operations.go
+++ b/redbench/internal/redis/operations.go
@@ -3,6 +3,7 @@ package redis
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"time"
 
 	"github.com/simonasr/benchmarketing/redbench/pkg/utils"
@@ -183,8 +184,16 @@ func (o *Operations) SaveRandomHashData(ctx context.Context, expiration int32, k
 
 	fields := make([]string, 0, batchSize)
 	fv := make(map[string]string, batchSize)
+	// Determine the minimum base36 width required to represent batchSize-1 without collisions
+	width := 1
+	if batchSize > 1 {
+		w := len(strconv.FormatInt(int64(batchSize-1), 36))
+		if w > width {
+			width = w
+		}
+	}
 	for i := 0; i < batchSize; i++ {
-		field := "f" + utils.Base36Padded(i, counterPadLen)
+		field := "f" + utils.Base36Padded(i, width)
 		fields = append(fields, field)
 		fv[field] = utils.RandomString(fieldValueSize)
 	}

--- a/redbench/internal/redis/operations.go
+++ b/redbench/internal/redis/operations.go
@@ -114,8 +114,15 @@ func (o *Operations) SaveRandomBatchData(ctx context.Context, expiration int32, 
 	for i := 0; i < batchSize; i++ {
 		var key string
 		if sameSlotTag != "" {
-			// Use deterministic base36 counter suffix to guarantee uniqueness
-			key = utils.ComposeTaggedKeyWithCounter(sameSlotTag, keySize, defaultTaggedSuffixLen, i)
+			// Use deterministic base36 counter suffix sized to batchSize to guarantee uniqueness
+			suffixLen := 1
+			if batchSize > 1 {
+				w := len(strconv.FormatInt(int64(batchSize-1), 36))
+				if w > suffixLen {
+					suffixLen = w
+				}
+			}
+			key = utils.ComposeTaggedKeyWithCounter(sameSlotTag, keySize, suffixLen, i)
 		} else {
 			key = utils.RandomString(keySize)
 			// Guarantee uniqueness for non-tagged case by appending a base36 counter if collision

--- a/redbench/internal/redis/operations.go
+++ b/redbench/internal/redis/operations.go
@@ -3,7 +3,6 @@ package redis
 import (
 	"context"
 	"fmt"
-	"strconv"
 	"time"
 
 	"github.com/simonasr/benchmarketing/redbench/pkg/utils"
@@ -115,13 +114,7 @@ func (o *Operations) SaveRandomBatchData(ctx context.Context, expiration int32, 
 		var key string
 		if sameSlotTag != "" {
 			// Use deterministic base36 counter suffix sized to batchSize to guarantee uniqueness
-			suffixLen := 1
-			if batchSize > 1 {
-				w := len(strconv.FormatInt(int64(batchSize-1), 36))
-				if w > suffixLen {
-					suffixLen = w
-				}
-			}
+			suffixLen := utils.Base36WidthForMax(batchSize - 1)
 			key = utils.ComposeTaggedKeyWithCounter(sameSlotTag, keySize, suffixLen, i)
 		} else {
 			key = utils.RandomString(keySize)
@@ -192,13 +185,7 @@ func (o *Operations) SaveRandomHashData(ctx context.Context, expiration int32, k
 	fields := make([]string, 0, batchSize)
 	fv := make(map[string]string, batchSize)
 	// Determine the minimum base36 width required to represent batchSize-1 without collisions
-	width := 1
-	if batchSize > 1 {
-		w := len(strconv.FormatInt(int64(batchSize-1), 36))
-		if w > width {
-			width = w
-		}
-	}
+	width := utils.Base36WidthForMax(batchSize - 1)
 	for i := 0; i < batchSize; i++ {
 		field := "f" + utils.Base36Padded(i, width)
 		fields = append(fields, field)

--- a/redbench/internal/redis/operations_test.go
+++ b/redbench/internal/redis/operations_test.go
@@ -290,3 +290,40 @@ func TestGetBatchData(t *testing.T) {
 	mockClient.AssertExpectations(t)
 	mockMetrics.AssertExpectations(t)
 }
+
+func TestSaveRandomHashData_DynamicWidth_NoCollisions(t *testing.T) {
+	mockClient := new(MockClient)
+	mockMetrics := &MockMetrics{}
+
+	ops := NewOperations(mockClient, mockMetrics, false)
+
+	ctx := context.Background()
+	expiration := int32(0)
+	keySize := 8
+	fieldValueSize := 4
+	batchSize := 44 // greater than 36 to validate width>1
+
+	// Capture the map passed to HSet and assert it has batchSize unique fields
+	mockClient.On("HSet", ctx, mock.AnythingOfType("string"), mock.MatchedBy(func(fv map[string]string) bool {
+		if len(fv) != batchSize {
+			return false
+		}
+		// Ensure keys are unique
+		seen := make(map[string]struct{}, len(fv))
+		for k := range fv {
+			if _, ok := seen[k]; ok {
+				return false
+			}
+			seen[k] = struct{}{}
+		}
+		return true
+	})).Return(nil)
+	mockMetrics.On("ObserveHSetDuration", mock.AnythingOfType("float64")).Return()
+
+	key, fields, err := ops.SaveRandomHashData(ctx, expiration, keySize, fieldValueSize, batchSize, "")
+	assert.NoError(t, err)
+	assert.NotEmpty(t, key)
+	assert.Equal(t, batchSize, len(fields))
+
+	mockClient.AssertExpectations(t)
+}

--- a/redbench/pkg/utils/random.go
+++ b/redbench/pkg/utils/random.go
@@ -158,3 +158,12 @@ func ComposeTaggedKeyWithCounter(tag string, keySize int, suffixLen int, counter
 	}
 	return "{" + tagInner + "}" + suffix
 }
+
+// Base36WidthForMax returns the minimal width required to represent n in base36.
+// Always returns at least 1.
+func Base36WidthForMax(n int) int {
+	if n <= 0 {
+		return 1
+	}
+	return len(strconv.FormatInt(int64(n), 36))
+}


### PR DESCRIPTION
This PR fixes hash batch operations by implementing dynamic width calculation for base36 counters to prevent collisions. The changes ensure that field names and tagged keys have sufficient width to accommodate the batch size, replacing hardcoded width values with calculated ones.

- Adds `Base36WidthForMax` utility function to calculate minimum base36 width needed
- Updates hash field generation to use dynamic width based on batch size
- Fixes tagged key generation to scale suffix length with batch size
- Adds expiration support to ZUnion operations